### PR TITLE
fix: satisfy ruff DTZ901 and FURB162 to unblock CI

### DIFF
--- a/custom_components/hevy/binary_sensor.py
+++ b/custom_components/hevy/binary_sensor.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 from typing import TYPE_CHECKING, Any, Final
 
 from homeassistant.components.binary_sensor import (
@@ -47,7 +47,8 @@ WORKOUT_TODAY_DESCRIPTION: Final = HevyBinarySensorEntityDescription(
     entity_category=EntityCategory.DIAGNOSTIC,
     is_on_fn=lambda data: any(
         [
-            workout.get("start_time", datetime.min).date() == datetime.now().date()
+            workout.get("start_time", datetime.min.replace(tzinfo=UTC)).date()
+            == datetime.now(tz=UTC).date()
             for workout in data.get("workouts", {}).values()
         ]
     ),
@@ -61,7 +62,8 @@ WORKOUT_WEEK_DESCRIPTION: Final = HevyBinarySensorEntityDescription(
     entity_category=EntityCategory.DIAGNOSTIC,
     is_on_fn=lambda data: any(
         (
-            datetime.now().date() - workout.get("start_time", datetime.min).date()
+            datetime.now(tz=UTC).date()
+            - workout.get("start_time", datetime.min.replace(tzinfo=UTC)).date()
             < timedelta(days=7)
             for workout in data.get("workouts", {}).values()
         )

--- a/custom_components/hevy/coordinator.py
+++ b/custom_components/hevy/coordinator.py
@@ -69,9 +69,7 @@ class HevyDataUpdateCoordinator(DataUpdateCoordinator):
 
             for workout in workouts_data.get("workouts", []):
                 workout_id = workout["id"]
-                workout_start_time = datetime.fromisoformat(
-                    workout["start_time"].replace("Z", "+00:00")
-                )
+                workout_start_time = datetime.fromisoformat(workout["start_time"])
                 workout_title = workout["title"]
 
                 workout_date = workout_start_time.date()


### PR DESCRIPTION
## Summary
- Ruff 0.15.12 (PR #68) flags 2 new rules in existing code, blocking dependabot lint CI.
- `binary_sensor.py`: add `tz=UTC` to `datetime.min` defaults and `datetime.now()` (DTZ901).
- `coordinator.py`: drop redundant `.replace("Z", "+00:00")` — `fromisoformat` accepts `Z` natively since Python 3.11 (FURB162).

Unblocks #67 and #68.

## Test plan
- [x] `ruff check .` passes
- [x] `ruff format . --check` passes
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced workout timestamp handling to ensure accurate timezone interpretation when determining if a workout occurred today or this week.

* **Refactor**
  * Optimized internal time parsing logic.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hudsonbrendon/HA-hevy/pull/69?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->