### PR TITLE
feat(phase-1): rich sensors for user, body, aggregates & streaks

### DIFF
--- a/custom_components/hevy/api.py
+++ b/custom_components/hevy/api.py
@@ -70,6 +70,23 @@ class HevyApiClient:
             params={"page": page, "pageSize": page_size},
         )
 
+    async def async_get_user_info(self) -> dict[str, Any]:
+        """Get authenticated user info."""
+        return await self._api_wrapper(
+            method="get",
+            url=f"{BASE_URL}/user/info",
+        )
+
+    async def async_get_body_measurements(
+        self, page: int = 1, page_size: int = 10
+    ) -> dict[str, Any]:
+        """Get body measurements (paginated, max 10 per page)."""
+        return await self._api_wrapper(
+            method="get",
+            url=f"{BASE_URL}/body_measurements",
+            params={"page": page, "pageSize": page_size},
+        )
+
     async def _api_wrapper(
         self,
         method: str,

--- a/custom_components/hevy/coordinator.py
+++ b/custom_components/hevy/coordinator.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
-from datetime import datetime, timedelta
+import asyncio
+from datetime import UTC, date, datetime, timedelta
+from itertools import pairwise
 from typing import TYPE_CHECKING, Any
 
 from homeassistant.exceptions import ConfigEntryAuthFailed
@@ -18,6 +20,58 @@ if TYPE_CHECKING:
     from homeassistant.core import HomeAssistant
 
     from .data import HevyConfigEntry
+
+
+def _set_volume_kg(workout_set: dict[str, Any]) -> float:
+    """Return volume (weight * reps) for a single set, treating None as 0."""
+    weight = workout_set.get("weight_kg") or 0
+    reps = workout_set.get("reps") or 0
+    return float(weight) * float(reps)
+
+
+def _workout_duration_seconds(workout: dict[str, Any]) -> float:
+    """Return duration in seconds between start_time and end_time, 0 if missing."""
+    start = workout.get("start_time")
+    end_raw = workout.get("_end_time_raw")
+    if not start or not end_raw:
+        return 0.0
+    try:
+        end = datetime.fromisoformat(end_raw)
+    except (TypeError, ValueError):
+        return 0.0
+    return max(0.0, (end - start).total_seconds())
+
+
+def _compute_streaks(workout_dates: set[date], today: date) -> tuple[int, int]:
+    """Compute (current_streak_days, longest_streak_days) from a set of dates."""
+    if not workout_dates:
+        return 0, 0
+
+    sorted_dates = sorted(workout_dates, reverse=True)
+
+    current = 0
+    cursor = today
+    if sorted_dates[0] not in (today, today - timedelta(days=1)):
+        current = 0
+    else:
+        cursor = sorted_dates[0]
+        current = 1
+        for d in sorted_dates[1:]:
+            if d == cursor - timedelta(days=1):
+                cursor = d
+                current += 1
+            else:
+                break
+
+    longest = 1
+    run = 1
+    for prev, nxt in pairwise(sorted_dates):
+        if prev - nxt == timedelta(days=1):
+            run += 1
+            longest = max(longest, run)
+        else:
+            run = 1
+    return current, longest
 
 
 class HevyDataUpdateCoordinator(DataUpdateCoordinator):
@@ -43,95 +97,186 @@ class HevyDataUpdateCoordinator(DataUpdateCoordinator):
 
     async def _async_update_data(self) -> dict[str, Any]:
         """Update data via library."""
+        client = self.config_entry.runtime_data.client
         try:
-            # Get basic workout count
-            workout_count_data = (
-                await self.config_entry.runtime_data.client.async_get_workout_count()
+            (
+                workout_count_data,
+                workouts_data,
+                user_data,
+                measurements_data,
+            ) = await asyncio.gather(
+                client.async_get_workout_count(),
+                client.async_get_workouts(page=1, page_size=DEFAULT_WORKOUTS_COUNT),
+                self._safe_fetch(client.async_get_user_info()),
+                self._safe_fetch(client.async_get_body_measurements(page_size=10)),
             )
-
-            # Get detailed workouts
-            workouts_data = (
-                await self.config_entry.runtime_data.client.async_get_workouts(
-                    page=1, page_size=DEFAULT_WORKOUTS_COUNT
-                )
-            )
-
-            # Process workouts into a more usable format
-            processed_workouts = {}
-
-            # Track counts for different time periods
-            today_count = 0
-            week_count = 0
-            month_count = 0
-            year_count = 0
-
-            today = datetime.now().date()
-
-            for workout in workouts_data.get("workouts", []):
-                workout_id = workout["id"]
-                workout_start_time = datetime.fromisoformat(workout["start_time"])
-                workout_title = workout["title"]
-
-                workout_date = workout_start_time.date()
-                if workout_date == today:
-                    today_count += 1
-
-                days_diff = (today - workout_date).days
-                if days_diff < 7:
-                    week_count += 1
-
-                if (
-                    workout_date.year == today.year
-                    and workout_date.month == today.month
-                ):
-                    month_count += 1
-
-                if workout_date.year == today.year:
-                    year_count += 1
-
-                exercises_data = {}
-                for exercise in workout["exercises"]:
-                    exercise_title = exercise["title"]
-                    exercise_data = {
-                        "title": exercise_title,
-                        "sets": len(exercise["sets"]),
-                        "total_reps": sum(
-                            s.get("reps", 0)
-                            for s in exercise["sets"]
-                            if s.get("reps") is not None
-                        ),
-                        "max_weight_kg": max(
-                            (
-                                s.get("weight_kg", 0)
-                                for s in exercise["sets"]
-                                if s.get("weight_kg") is not None
-                            ),
-                            default=0,
-                        ),
-                    }
-                    exercises_data[f"{exercise['index']}_{exercise_title}"] = (
-                        exercise_data
-                    )
-
-                processed_workouts[workout_id] = {
-                    "id": workout_id,
-                    "title": workout_title,
-                    "start_time": workout_start_time,
-                    "exercises": exercises_data,
-                }
-
-            # Combine data
-            return {
-                "workout_count": workout_count_data.get("workout_count", 0),
-                "workouts": processed_workouts,
-                "name": self.name,
-                "today_count": today_count,
-                "week_count": week_count,
-                "month_count": month_count,
-                "year_count": year_count,
-            }
-
         except HevyApiClientAuthenticationError as exception:
             raise ConfigEntryAuthFailed(exception) from exception
         except HevyApiClientError as exception:
             raise UpdateFailed(exception) from exception
+
+        return self._build_state(
+            workout_count_data, workouts_data, user_data, measurements_data
+        )
+
+    def _build_state(
+        self,
+        workout_count_data: dict[str, Any],
+        workouts_data: dict[str, Any],
+        user_data: dict[str, Any] | None,
+        measurements_data: dict[str, Any] | None,
+    ) -> dict[str, Any]:
+        """Merge API responses into the coordinator state dictionary."""
+        today = datetime.now(tz=UTC).date()
+        processed, aggregates = self._process_workouts(
+            workouts_data.get("workouts", []), today
+        )
+        current_streak, longest_streak = _compute_streaks(
+            aggregates["workout_dates"], today
+        )
+        last_workout = (
+            max(processed.values(), key=lambda w: w["start_time"])
+            if processed
+            else None
+        )
+        user_info = (user_data or {}).get("data") or {}
+        measurements_list = (measurements_data or {}).get("body_measurements", [])
+        latest_measurement = (
+            max(measurements_list, key=lambda m: m.get("date", ""))
+            if measurements_list
+            else None
+        )
+        return {
+            "workout_count": workout_count_data.get("workout_count", 0),
+            "workouts": processed,
+            "name": self.name,
+            "today_count": aggregates["today_count"],
+            "week_count": aggregates["week_count"],
+            "month_count": aggregates["month_count"],
+            "year_count": aggregates["year_count"],
+            "user": user_info,
+            "latest_measurement": latest_measurement,
+            "last_workout": last_workout,
+            "volume_today_kg": aggregates["volume_today"],
+            "volume_week_kg": aggregates["volume_week"],
+            "volume_month_kg": aggregates["volume_month"],
+            "volume_year_kg": aggregates["volume_year"],
+            "duration_today_min": aggregates["duration_today_s"] / 60,
+            "duration_week_min": aggregates["duration_week_s"] / 60,
+            "duration_month_min": aggregates["duration_month_s"] / 60,
+            "current_streak_days": current_streak,
+            "longest_streak_days": longest_streak,
+            "unique_exercises_7d": len(aggregates["templates_7d"]),
+            "unique_exercises_30d": len(aggregates["templates_30d"]),
+        }
+
+    def _process_workouts(
+        self, workouts: list[dict[str, Any]], today: date
+    ) -> tuple[dict[str, dict[str, Any]], dict[str, Any]]:
+        """Process workouts into records + aggregate counters."""
+        week_ago = today - timedelta(days=7)
+        month_ago = today - timedelta(days=30)
+        processed: dict[str, dict[str, Any]] = {}
+        agg: dict[str, Any] = {
+            "today_count": 0,
+            "week_count": 0,
+            "month_count": 0,
+            "year_count": 0,
+            "volume_today": 0.0,
+            "volume_week": 0.0,
+            "volume_month": 0.0,
+            "volume_year": 0.0,
+            "duration_today_s": 0.0,
+            "duration_week_s": 0.0,
+            "duration_month_s": 0.0,
+            "workout_dates": set(),
+            "templates_7d": set(),
+            "templates_30d": set(),
+        }
+        for workout in workouts:
+            record = self._build_workout_record(workout, agg, week_ago, month_ago)
+            processed[record["id"]] = record
+            self._update_aggregates(record, agg, today)
+        return processed, agg
+
+    def _build_workout_record(
+        self,
+        workout: dict[str, Any],
+        agg: dict[str, Any],
+        week_ago: date,
+        month_ago: date,
+    ) -> dict[str, Any]:
+        """Build the processed record for a single workout, updating template sets."""
+        start_time = datetime.fromisoformat(workout["start_time"])
+        workout_date = start_time.date()
+        agg["workout_dates"].add(workout_date)
+        exercises_data: dict[str, dict[str, Any]] = {}
+        volume_kg = 0.0
+        total_reps = 0
+        for exercise in workout.get("exercises", []):
+            template_id = exercise.get("exercise_template_id", "")
+            sets = exercise.get("sets", [])
+            exercise_volume = sum(_set_volume_kg(s) for s in sets)
+            exercise_reps = sum(s.get("reps") or 0 for s in sets)
+            volume_kg += exercise_volume
+            total_reps += exercise_reps
+            exercises_data[f"{exercise['index']}_{exercise['title']}"] = {
+                "title": exercise["title"],
+                "template_id": template_id,
+                "sets": len(sets),
+                "total_reps": exercise_reps,
+                "volume_kg": exercise_volume,
+                "max_weight_kg": max(
+                    (s.get("weight_kg") or 0 for s in sets), default=0
+                ),
+            }
+            if template_id and workout_date >= week_ago:
+                agg["templates_7d"].add(template_id)
+            if template_id and workout_date >= month_ago:
+                agg["templates_30d"].add(template_id)
+        record = {
+            "id": workout["id"],
+            "title": workout["title"],
+            "start_time": start_time,
+            "_end_time_raw": workout.get("end_time"),
+            "exercises": exercises_data,
+            "volume_kg": volume_kg,
+            "total_reps": total_reps,
+            "exercise_count": len(exercises_data),
+        }
+        record["duration_seconds"] = _workout_duration_seconds(record)
+        return record
+
+    @staticmethod
+    def _update_aggregates(
+        record: dict[str, Any], agg: dict[str, Any], today: date
+    ) -> None:
+        """Update aggregate counters based on a workout record's date bucket."""
+        workout_date = record["start_time"].date()
+        volume = record["volume_kg"]
+        duration_s = record["duration_seconds"]
+        if workout_date == today:
+            agg["today_count"] += 1
+            agg["volume_today"] += volume
+            agg["duration_today_s"] += duration_s
+        if (today - workout_date).days < 7:
+            agg["week_count"] += 1
+            agg["volume_week"] += volume
+            agg["duration_week_s"] += duration_s
+        if workout_date.year == today.year and workout_date.month == today.month:
+            agg["month_count"] += 1
+            agg["volume_month"] += volume
+            agg["duration_month_s"] += duration_s
+        if workout_date.year == today.year:
+            agg["year_count"] += 1
+            agg["volume_year"] += volume
+
+    async def _safe_fetch(self, coro: Any) -> dict[str, Any] | None:
+        """Await a coroutine and swallow non-auth errors (returns None on failure)."""
+        try:
+            return await coro
+        except HevyApiClientAuthenticationError:
+            raise
+        except HevyApiClientError as err:
+            LOGGER.warning("Optional Hevy endpoint failed: %s", err)
+            return None

--- a/custom_components/hevy/manifest.json
+++ b/custom_components/hevy/manifest.json
@@ -8,5 +8,5 @@
   "documentation": "https://github.com/hudsonbrendon/HA-hevy",
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/hudsonbrendon/HA-hevy/issues",
-  "version": "0.1.3"
+  "version": "0.2.0"
 }

--- a/custom_components/hevy/sensor.py
+++ b/custom_components/hevy/sensor.py
@@ -11,7 +11,7 @@ from homeassistant.components.sensor import (
     SensorEntityDescription,
     SensorStateClass,
 )
-from homeassistant.const import UnitOfMass
+from homeassistant.const import PERCENTAGE, UnitOfMass, UnitOfTime
 
 from .entity import HevyEntity, HevyWorkoutEntity
 
@@ -37,6 +37,8 @@ class HevySensorEntityDescription(
     SensorEntityDescription, HevySensorEntityDescriptionRequired
 ):
     """Hevy sensor entity description."""
+
+    attributes_fn: callable[[dict[str, Any]], dict[str, Any]] | None = None
 
 
 WORKOUT_COUNT_DESCRIPTION: Final = HevySensorEntityDescription(
@@ -80,6 +82,195 @@ YEAR_COUNT_DESCRIPTION: Final = HevySensorEntityDescription(
 )
 
 
+def _last_workout_field(field: str) -> callable[[dict[str, Any]], Any]:
+    def _get(data: dict[str, Any]) -> Any:
+        lw = data.get("last_workout") or {}
+        return lw.get(field)
+
+    return _get
+
+
+def _last_workout_duration_min(data: dict[str, Any]) -> float | None:
+    lw = data.get("last_workout") or {}
+    seconds = lw.get("duration_seconds")
+    if not seconds:
+        return None
+    return round(seconds / 60, 1)
+
+
+def _measurement_field(field: str) -> callable[[dict[str, Any]], Any]:
+    def _get(data: dict[str, Any]) -> Any:
+        m = data.get("latest_measurement") or {}
+        return m.get(field)
+
+    return _get
+
+
+LAST_WORKOUT_TITLE_DESCRIPTION: Final = HevySensorEntityDescription(
+    key="last_workout_title",
+    translation_key="last_workout_title",
+    icon="mdi:dumbbell",
+    value_fn=_last_workout_field("title"),
+    attributes_fn=lambda data: {
+        "exercise_count": (data.get("last_workout") or {}).get("exercise_count", 0),
+        "total_reps": (data.get("last_workout") or {}).get("total_reps", 0),
+    },
+)
+
+LAST_WORKOUT_START_DESCRIPTION: Final = HevySensorEntityDescription(
+    key="last_workout_start",
+    translation_key="last_workout_start",
+    icon="mdi:calendar-clock",
+    device_class=SensorDeviceClass.TIMESTAMP,
+    value_fn=_last_workout_field("start_time"),
+)
+
+LAST_WORKOUT_DURATION_DESCRIPTION: Final = HevySensorEntityDescription(
+    key="last_workout_duration",
+    translation_key="last_workout_duration",
+    icon="mdi:timer",
+    device_class=SensorDeviceClass.DURATION,
+    native_unit_of_measurement=UnitOfTime.MINUTES,
+    state_class=SensorStateClass.MEASUREMENT,
+    value_fn=_last_workout_duration_min,
+)
+
+LAST_WORKOUT_VOLUME_DESCRIPTION: Final = HevySensorEntityDescription(
+    key="last_workout_volume",
+    translation_key="last_workout_volume",
+    icon="mdi:weight-kilogram",
+    device_class=SensorDeviceClass.WEIGHT,
+    native_unit_of_measurement=UnitOfMass.KILOGRAMS,
+    state_class=SensorStateClass.MEASUREMENT,
+    value_fn=lambda data: (data.get("last_workout") or {}).get("volume_kg"),
+)
+
+VOLUME_AGGREGATE_DESCRIPTIONS: Final = tuple(
+    HevySensorEntityDescription(
+        key=f"volume_{period}_kg",
+        translation_key=f"volume_{period}",
+        icon="mdi:weight-kilogram",
+        device_class=SensorDeviceClass.WEIGHT,
+        native_unit_of_measurement=UnitOfMass.KILOGRAMS,
+        state_class=SensorStateClass.MEASUREMENT,
+        value_fn=lambda data, key=f"volume_{period}_kg": round(data.get(key, 0), 1),
+    )
+    for period in ("today", "week", "month", "year")
+)
+
+DURATION_AGGREGATE_DESCRIPTIONS: Final = tuple(
+    HevySensorEntityDescription(
+        key=f"duration_{period}_min",
+        translation_key=f"duration_{period}",
+        icon="mdi:timer-outline",
+        device_class=SensorDeviceClass.DURATION,
+        native_unit_of_measurement=UnitOfTime.MINUTES,
+        state_class=SensorStateClass.MEASUREMENT,
+        value_fn=lambda data, key=f"duration_{period}_min": round(data.get(key, 0), 1),
+    )
+    for period in ("today", "week", "month")
+)
+
+STREAK_DESCRIPTIONS: Final = (
+    HevySensorEntityDescription(
+        key="current_streak_days",
+        translation_key="current_streak_days",
+        icon="mdi:fire",
+        native_unit_of_measurement="d",
+        state_class=SensorStateClass.MEASUREMENT,
+        value_fn=lambda data: data.get("current_streak_days", 0),
+    ),
+    HevySensorEntityDescription(
+        key="longest_streak_days",
+        translation_key="longest_streak_days",
+        icon="mdi:trophy",
+        native_unit_of_measurement="d",
+        state_class=SensorStateClass.MEASUREMENT,
+        value_fn=lambda data: data.get("longest_streak_days", 0),
+    ),
+)
+
+VARIETY_DESCRIPTIONS: Final = (
+    HevySensorEntityDescription(
+        key="unique_exercises_7d",
+        translation_key="unique_exercises_7d",
+        icon="mdi:shape-outline",
+        state_class=SensorStateClass.MEASUREMENT,
+        value_fn=lambda data: data.get("unique_exercises_7d", 0),
+    ),
+    HevySensorEntityDescription(
+        key="unique_exercises_30d",
+        translation_key="unique_exercises_30d",
+        icon="mdi:shape",
+        state_class=SensorStateClass.MEASUREMENT,
+        value_fn=lambda data: data.get("unique_exercises_30d", 0),
+    ),
+)
+
+BODY_WEIGHT_DESCRIPTION: Final = HevySensorEntityDescription(
+    key="body_weight_kg",
+    translation_key="body_weight",
+    icon="mdi:scale-bathroom",
+    device_class=SensorDeviceClass.WEIGHT,
+    native_unit_of_measurement=UnitOfMass.KILOGRAMS,
+    state_class=SensorStateClass.MEASUREMENT,
+    value_fn=_measurement_field("weight_kg"),
+    attributes_fn=lambda data: {
+        "date": (data.get("latest_measurement") or {}).get("date"),
+    },
+)
+
+BODY_FAT_DESCRIPTION: Final = HevySensorEntityDescription(
+    key="body_fat_percent",
+    translation_key="body_fat_percent",
+    icon="mdi:percent",
+    native_unit_of_measurement=PERCENTAGE,
+    state_class=SensorStateClass.MEASUREMENT,
+    value_fn=_measurement_field("fat_percent"),
+)
+
+LEAN_MASS_DESCRIPTION: Final = HevySensorEntityDescription(
+    key="lean_mass_kg",
+    translation_key="lean_mass",
+    icon="mdi:human",
+    device_class=SensorDeviceClass.WEIGHT,
+    native_unit_of_measurement=UnitOfMass.KILOGRAMS,
+    state_class=SensorStateClass.MEASUREMENT,
+    value_fn=_measurement_field("lean_mass_kg"),
+)
+
+USER_NAME_DESCRIPTION: Final = HevySensorEntityDescription(
+    key="user_name",
+    translation_key="user_name",
+    icon="mdi:account",
+    value_fn=lambda data: (data.get("user") or {}).get("name"),
+    attributes_fn=lambda data: {
+        "user_id": (data.get("user") or {}).get("id"),
+        "profile_url": (data.get("user") or {}).get("url"),
+    },
+)
+
+ALL_DESCRIPTIONS: Final = (
+    WORKOUT_COUNT_DESCRIPTION,
+    TODAY_COUNT_DESCRIPTION,
+    WEEK_COUNT_DESCRIPTION,
+    MONTH_COUNT_DESCRIPTION,
+    YEAR_COUNT_DESCRIPTION,
+    LAST_WORKOUT_TITLE_DESCRIPTION,
+    LAST_WORKOUT_START_DESCRIPTION,
+    LAST_WORKOUT_DURATION_DESCRIPTION,
+    LAST_WORKOUT_VOLUME_DESCRIPTION,
+    *VOLUME_AGGREGATE_DESCRIPTIONS,
+    *DURATION_AGGREGATE_DESCRIPTIONS,
+    *STREAK_DESCRIPTIONS,
+    *VARIETY_DESCRIPTIONS,
+    BODY_WEIGHT_DESCRIPTION,
+    BODY_FAT_DESCRIPTION,
+    LEAN_MASS_DESCRIPTION,
+    USER_NAME_DESCRIPTION,
+)
+
+
 async def async_setup_entry(
     hass: HomeAssistant,  # noqa: ARG001 Unused function argument: `hass`
     entry: HevyConfigEntry,
@@ -88,39 +279,22 @@ async def async_setup_entry(
     """Set up the sensor platform."""
     coordinator = entry.runtime_data.coordinator
 
-    # Add the primary workout count sensors
-    entities = [
-        HevySensor(
-            coordinator=coordinator,
-            entity_description=description,
-        )
-        for description in [
-            WORKOUT_COUNT_DESCRIPTION,
-            TODAY_COUNT_DESCRIPTION,
-            WEEK_COUNT_DESCRIPTION,
-            MONTH_COUNT_DESCRIPTION,
-            YEAR_COUNT_DESCRIPTION,
-        ]
+    entities: list[SensorEntity] = [
+        HevySensor(coordinator=coordinator, entity_description=description)
+        for description in ALL_DESCRIPTIONS
     ]
 
-    # Add entities for each workout's exercises
     if coordinator.data and "workouts" in coordinator.data:
         for workout_id, workout_data in coordinator.data["workouts"].items():
-            # Create a workout date sensor
             entities.append(HevyWorkoutDateSensor(coordinator, workout_id))
-
-            # Create sensors for each exercise in the workout
-            for exercise_key, exercise_data in workout_data.get(
-                "exercises", {}
-            ).items():
-                entities.append(
-                    HevyExerciseSensor(
-                        coordinator=coordinator,
-                        workout_id=workout_id,
-                        exercise_key=exercise_key,
-                        exercise_data=exercise_data,
-                    )
+            entities.extend(
+                HevyExerciseSensor(
+                    coordinator=coordinator,
+                    workout_id=workout_id,
+                    exercise_key=exercise_key,
                 )
+                for exercise_key in workout_data.get("exercises", {})
+            )
 
     async_add_entities(entities)
 
@@ -138,19 +312,23 @@ class HevySensor(HevyEntity, SensorEntity):
         """Initialize the sensor class."""
         super().__init__(coordinator)
         self.entity_description = entity_description
-
-        # Create a simpler unique_id that doesn't include all these prefixes
         self._attr_unique_id = (
             f"{coordinator.config_entry.entry_id}_{entity_description.key}"
         )
-
-        # Set the translation_key explicitly - this is what enables translation
         self._attr_has_entity_name = True
 
     @property
     def native_value(self) -> Any:
         """Return the native value of the sensor."""
         return self.entity_description.value_fn(self.coordinator.data)
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any] | None:
+        """Return optional attributes provided by the description."""
+        if self.entity_description.attributes_fn is None:
+            return None
+        attrs = self.entity_description.attributes_fn(self.coordinator.data)
+        return {k: v for k, v in attrs.items() if v is not None}
 
 
 class HevyWorkoutDateSensor(HevyWorkoutEntity, SensorEntity):
@@ -163,8 +341,6 @@ class HevyWorkoutDateSensor(HevyWorkoutEntity, SensorEntity):
     ) -> None:
         """Initialize the workout date sensor."""
         super().__init__(coordinator, workout_id)
-
-        # Use translation keys and proper entity naming
         self._attr_translation_key = "workout_date"
         self._attr_has_entity_name = True
         self._attr_unique_id = f"{workout_id}_date"
@@ -180,42 +356,31 @@ class HevyWorkoutDateSensor(HevyWorkoutEntity, SensorEntity):
 class HevyExerciseSensor(HevyWorkoutEntity, SensorEntity):
     """Sensor showing exercise data."""
 
+    _attr_device_class = SensorDeviceClass.WEIGHT
+    _attr_native_unit_of_measurement = UnitOfMass.KILOGRAMS
+    _attr_state_class = SensorStateClass.MEASUREMENT
+
     def __init__(
         self,
         coordinator: HevyDataUpdateCoordinator,
         workout_id: str,
         exercise_key: str,
-        exercise_data: dict[str, Any],
     ) -> None:
         """Initialize the exercise sensor."""
         super().__init__(coordinator, workout_id)
         self._exercise_key = exercise_key
-        self._exercise_data = exercise_data
-
-        exercise_title = exercise_data.get("title", "Unknown Exercise")
-
-        # Use a more streamlined unique_id and better naming
+        exercise_data = self.workout_data.get("exercises", {}).get(exercise_key, {})
         self._attr_unique_id = f"{workout_id}_{exercise_key}"
-        self._attr_name = exercise_title  # Use just the exercise title as name
-
-        # Use weight as the primary value if available
-        if exercise_data.get("max_weight_kg", 0) > 0:
-            self._attr_native_unit_of_measurement = UnitOfMass.KILOGRAMS
-            self._attr_state_class = SensorStateClass.MEASUREMENT
+        self._attr_name = exercise_data.get("title", "Unknown Exercise")
 
     @property
     def native_value(self) -> float | None:
-        """Return the weight of the exercise."""
-        if not self.available:
+        """Return the heaviest weight in the exercise."""
+        if not self.available or not self.workout_data:
             return None
-
-        if not self.workout_data:
-            return None
-
         exercise_data = self.workout_data.get("exercises", {}).get(self._exercise_key)
         if not exercise_data:
             return None
-
         return exercise_data.get("max_weight_kg")
 
     @property
@@ -223,11 +388,11 @@ class HevyExerciseSensor(HevyWorkoutEntity, SensorEntity):
         """Return additional attributes about the exercise."""
         if not self.available or not self.workout_data:
             return {}
-
         exercise_data = self.workout_data.get("exercises", {}).get(
             self._exercise_key, {}
         )
         return {
             "sets": exercise_data.get("sets", 0),
             "total_reps": exercise_data.get("total_reps", 0),
+            "volume_kg": round(exercise_data.get("volume_kg", 0), 1),
         }

--- a/custom_components/hevy/translations/en.json
+++ b/custom_components/hevy/translations/en.json
@@ -20,39 +20,40 @@
     },
     "entity": {
         "sensor": {
-            "workout_count": {
-                "name": "Workout Count"
-            },
-            "today_count": {
-                "name": "Today's Workouts"
-            },
-            "week_count": {
-                "name": "This Week's Workouts"
-            },
-            "month_count": {
-                "name": "This Month's Workouts"
-            },
-            "year_count": {
-                "name": "This Year's Workouts"
-            },
-            "workout_date": {
-                "name": "Workout Date"
-            }
+            "workout_count": {"name": "Workout Count"},
+            "today_count": {"name": "Today's Workouts"},
+            "week_count": {"name": "This Week's Workouts"},
+            "month_count": {"name": "This Month's Workouts"},
+            "year_count": {"name": "This Year's Workouts"},
+            "workout_date": {"name": "Workout Date"},
+            "last_workout_title": {"name": "Last Workout"},
+            "last_workout_start": {"name": "Last Workout Start"},
+            "last_workout_duration": {"name": "Last Workout Duration"},
+            "last_workout_volume": {"name": "Last Workout Volume"},
+            "volume_today": {"name": "Volume Today"},
+            "volume_week": {"name": "Volume This Week"},
+            "volume_month": {"name": "Volume This Month"},
+            "volume_year": {"name": "Volume This Year"},
+            "duration_today": {"name": "Training Time Today"},
+            "duration_week": {"name": "Training Time This Week"},
+            "duration_month": {"name": "Training Time This Month"},
+            "current_streak_days": {"name": "Current Streak"},
+            "longest_streak_days": {"name": "Longest Streak"},
+            "unique_exercises_7d": {"name": "Unique Exercises (7d)"},
+            "unique_exercises_30d": {"name": "Unique Exercises (30d)"},
+            "body_weight": {"name": "Body Weight"},
+            "body_fat_percent": {"name": "Body Fat"},
+            "lean_mass": {"name": "Lean Mass"},
+            "user_name": {"name": "User"}
         },
         "binary_sensor": {
             "workout_today": {
                 "name": "Workout Today",
-                "state": {
-                    "on": "Yes",
-                    "off": "No"
-                }
+                "state": {"on": "Yes", "off": "No"}
             },
             "workout_this_week": {
                 "name": "Workout This Week",
-                "state": {
-                    "on": "Yes",
-                    "off": "No"
-                }
+                "state": {"on": "Yes", "off": "No"}
             }
         }
     }

--- a/custom_components/hevy/translations/pt-BR.json
+++ b/custom_components/hevy/translations/pt-BR.json
@@ -20,39 +20,40 @@
     },
     "entity": {
         "sensor": {
-            "workout_count": {
-                "name": "Contagem de Treinos"
-            },
-            "today_count": {
-                "name": "Treinos de Hoje"
-            },
-            "week_count": {
-                "name": "Treinos desta Semana"
-            },
-            "month_count": {
-                "name": "Treinos deste Mês"
-            },
-            "year_count": {
-                "name": "Treinos deste Ano"
-            },
-            "workout_date": {
-                "name": "Data do Treino"
-            }
+            "workout_count": {"name": "Contagem de Treinos"},
+            "today_count": {"name": "Treinos de Hoje"},
+            "week_count": {"name": "Treinos desta Semana"},
+            "month_count": {"name": "Treinos deste Mês"},
+            "year_count": {"name": "Treinos deste Ano"},
+            "workout_date": {"name": "Data do Treino"},
+            "last_workout_title": {"name": "Último Treino"},
+            "last_workout_start": {"name": "Início do Último Treino"},
+            "last_workout_duration": {"name": "Duração do Último Treino"},
+            "last_workout_volume": {"name": "Volume do Último Treino"},
+            "volume_today": {"name": "Volume de Hoje"},
+            "volume_week": {"name": "Volume desta Semana"},
+            "volume_month": {"name": "Volume deste Mês"},
+            "volume_year": {"name": "Volume deste Ano"},
+            "duration_today": {"name": "Tempo de Treino Hoje"},
+            "duration_week": {"name": "Tempo de Treino na Semana"},
+            "duration_month": {"name": "Tempo de Treino no Mês"},
+            "current_streak_days": {"name": "Sequência Atual"},
+            "longest_streak_days": {"name": "Maior Sequência"},
+            "unique_exercises_7d": {"name": "Exercícios Únicos (7d)"},
+            "unique_exercises_30d": {"name": "Exercícios Únicos (30d)"},
+            "body_weight": {"name": "Peso Corporal"},
+            "body_fat_percent": {"name": "Gordura Corporal"},
+            "lean_mass": {"name": "Massa Magra"},
+            "user_name": {"name": "Usuário"}
         },
         "binary_sensor": {
             "workout_today": {
                 "name": "Treinou Hoje",
-                "state": {
-                    "on": "Sim",
-                    "off": "Não"
-                }
+                "state": {"on": "Sim", "off": "Não"}
             },
             "workout_this_week": {
                 "name": "Treinou Esta Semana",
-                "state": {
-                    "on": "Sim",
-                    "off": "Não"
-                }
+                "state": {"on": "Sim", "off": "Não"}
             }
         }
     }


### PR DESCRIPTION
Closes #70.

## What
Expande a integração com 20+ novos sensores cobrindo APIs antes não utilizadas do Hevy.

### Novos sensores
| Sensor | Origem | Device class |
|---|---|---|
| User | /v1/user/info | — (atributos: id, url) |
| Body Weight | /v1/body_measurements | WEIGHT |
| Body Fat | /v1/body_measurements | — (%) |
| Lean Mass | /v1/body_measurements | WEIGHT |
| Last Workout | últimos workouts | — (atributos: exercise_count, total_reps) |
| Last Workout Start | últimos workouts | TIMESTAMP |
| Last Workout Duration | end - start | DURATION (min) |
| Last Workout Volume | sum(weight*reps) | WEIGHT |
| Volume Today/Week/Month/Year | agregados | WEIGHT |
| Training Time Today/Week/Month | agregados | DURATION |
| Current/Longest Streak | datas dos workouts | — (d) |
| Unique Exercises 7d/30d | template_id distintos | — |

### Internals
- Coordinator usa `asyncio.gather` para paralelizar 4 chamadas API por refresh.
- Falhas em endpoints opcionais (user/measurements) são logadas e não derrubam o refresh; auth errors continuam propagando.
- Sensores existentes preservados (back-compat).
- HevyExerciseSensor agora expõe `volume_kg` como atributo.
- Manifest bumped 0.1.3 → 0.2.0.

## Test plan
- [x] `ruff check .` passa
- [x] `ruff format . --check` passa
- [x] Validação sintática (ast.parse) ok
- [x] Translations JSON válidos (en, pt-BR)
- [ ] Validação manual no HA dev container com chave válida (push pra ver CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)