### PR TITLE
test: pytest suite + fix latent auth-error swallow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,29 @@
+name: "Test"
+
+on:
+  push:
+    branches:
+      - "main"
+  pull_request:
+    branches:
+      - "main"
+
+jobs:
+  pytest:
+    name: "Pytest"
+    runs-on: "ubuntu-latest"
+    steps:
+      - name: "Checkout the repository"
+        uses: "actions/checkout@v4.2.2"
+
+      - name: "Set up Python"
+        uses: actions/setup-python@v5.5.0
+        with:
+          python-version: "3.13"
+          cache: "pip"
+
+      - name: "Install test requirements"
+        run: python3 -m pip install -r requirements-test.txt
+
+      - name: "Run pytest"
+        run: python3 -m pytest tests/ -v

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -23,6 +23,21 @@ ignore = [
     "I001", # Import block is un-sorted or un-formatted
 ]
 
+[lint.per-file-ignores]
+"tests/**" = [
+    "S101",    # assert is fine in tests
+    "ANN",     # don't require full type annotations on test funcs/fixtures
+    "D",       # docstrings optional in tests
+    "SLF001",  # private member access is the whole point of unit tests
+    "PLR2004", # magic numbers are fine in assertions
+    "INP001",  # tests dir is not an implicit namespace package
+    "PT004",   # fixture-without-return-type
+    "FBT001",  # boolean args in fixtures
+    "N818",    # internal stub names mirror HA classes
+    "ARG005",  # lambda stubs intentionally ignore args
+    "PLC0415", # late imports needed after stub injection
+]
+
 [lint.flake8-pytest-style]
 fixture-parentheses = false
 

--- a/custom_components/hevy/api.py
+++ b/custom_components/hevy/api.py
@@ -117,6 +117,8 @@ class HevyApiClient:
             raise HevyApiClientCommunicationError(
                 msg,
             ) from exception
+        except HevyApiClientError:
+            raise
         except Exception as exception:  # pylint: disable=broad-except
             msg = f"Something really wrong happened! - {exception}"
             raise HevyApiClientError(

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+testpaths = tests
+asyncio_mode = auto
+addopts = -ra --strict-markers

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,0 +1,3 @@
+-r requirements.txt
+pytest==8.3.4
+pytest-asyncio==0.25.2

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,250 @@
+"""Shared test fixtures.
+
+Stubs out the Home Assistant runtime so coordinator/api logic can be tested
+without installing the full HA core.
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+
+class _StubDataUpdateCoordinator:
+    """Minimal stand-in for homeassistant.helpers.update_coordinator."""
+
+    def __init__(
+        self,
+        hass: Any = None,
+        logger: Any = None,
+        name: str | None = None,
+        update_interval: Any = None,
+    ) -> None:
+        self.hass = hass
+        self.logger = logger
+        self.name = name
+        self.update_interval = update_interval
+
+
+class _StubUpdateFailed(Exception):
+    """Stub for UpdateFailed."""
+
+
+class _StubConfigEntryAuthFailed(Exception):
+    """Stub for ConfigEntryAuthFailed."""
+
+
+def _install_ha_stubs() -> None:
+    """Insert minimal Home Assistant modules into sys.modules."""
+
+    def _pkg(name: str, **attrs: Any) -> types.ModuleType:
+        module = types.ModuleType(name)
+        module.__path__ = []
+        for key, value in attrs.items():
+            setattr(module, key, value)
+        sys.modules[name] = module
+        return module
+
+    def _mod(name: str, **attrs: Any) -> types.ModuleType:
+        module = types.ModuleType(name)
+        for key, value in attrs.items():
+            setattr(module, key, value)
+        sys.modules[name] = module
+        return module
+
+    _pkg("homeassistant")
+    _mod(
+        "homeassistant.exceptions",
+        ConfigEntryAuthFailed=_StubConfigEntryAuthFailed,
+    )
+    _pkg("homeassistant.helpers")
+    _mod(
+        "homeassistant.helpers.update_coordinator",
+        DataUpdateCoordinator=_StubDataUpdateCoordinator,
+        UpdateFailed=_StubUpdateFailed,
+    )
+    _mod("homeassistant.core", HomeAssistant=object)
+    _mod("homeassistant.config_entries", ConfigEntry=object)
+    _mod(
+        "homeassistant.const",
+        Platform=types.SimpleNamespace(SENSOR="sensor", BINARY_SENSOR="binary_sensor"),
+    )
+    _mod(
+        "homeassistant.helpers.aiohttp_client",
+        async_get_clientsession=lambda _hass: None,
+    )
+    _mod("homeassistant.loader", async_get_integration=lambda *a, **k: None)
+
+
+_install_ha_stubs()
+
+ROOT = Path(__file__).resolve().parent.parent
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+
+# Pre-register the custom_components.hevy package without executing __init__.py
+# (its imports pull in too much HA surface).
+def _register_hevy_package() -> None:
+    if "custom_components.hevy.coordinator" in sys.modules:
+        return
+    import importlib.util
+
+    pkg_root = ROOT / "custom_components"
+    cc_pkg = types.ModuleType("custom_components")
+    cc_pkg.__path__ = [str(pkg_root)]
+    sys.modules["custom_components"] = cc_pkg
+    hevy_pkg = types.ModuleType("custom_components.hevy")
+    hevy_pkg.__path__ = [str(pkg_root / "hevy")]
+    sys.modules["custom_components.hevy"] = hevy_pkg
+
+    for submodule in ("const", "api", "data", "coordinator"):
+        spec = importlib.util.spec_from_file_location(
+            f"custom_components.hevy.{submodule}",
+            pkg_root / "hevy" / f"{submodule}.py",
+        )
+        module = importlib.util.module_from_spec(spec)
+        sys.modules[f"custom_components.hevy.{submodule}"] = module
+        spec.loader.exec_module(module)
+
+
+_register_hevy_package()
+
+
+class _FrozenDatetime(datetime):
+    """datetime subclass with a fixed now() for deterministic tests."""
+
+    _frozen_now = datetime(2026, 5, 17, 12, 0, tzinfo=UTC)
+
+    @classmethod
+    def now(cls, tz: Any = None) -> datetime:  # type: ignore[override]
+        return cls._frozen_now.astimezone(tz) if tz else cls._frozen_now
+
+
+@pytest.fixture
+def frozen_today() -> datetime:
+    """Return the fixed 'now' used by frozen_datetime."""
+    return _FrozenDatetime._frozen_now
+
+
+@pytest.fixture
+def freeze_coordinator_clock(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Patch coordinator.datetime to return a deterministic 'now'."""
+    import custom_components.hevy.coordinator as coord_mod
+
+    monkeypatch.setattr(coord_mod, "datetime", _FrozenDatetime)
+
+
+@pytest.fixture
+def coordinator() -> Any:
+    """Build a coordinator instance without running __init__ (no HA needed)."""
+    from custom_components.hevy.coordinator import HevyDataUpdateCoordinator
+
+    coord = HevyDataUpdateCoordinator.__new__(HevyDataUpdateCoordinator)
+    coord.name = "Hudson"
+    return coord
+
+
+@pytest.fixture
+def workouts_fixture() -> dict[str, Any]:
+    """Three workouts: today, yesterday, last month."""
+    return {
+        "workouts": [
+            {
+                "id": "w1",
+                "title": "Push Day",
+                "start_time": "2026-05-17T09:00:00+00:00",
+                "end_time": "2026-05-17T10:15:00+00:00",
+                "exercises": [
+                    {
+                        "index": 0,
+                        "title": "Bench Press",
+                        "exercise_template_id": "T1",
+                        "sets": [
+                            {"weight_kg": 80, "reps": 10},
+                            {"weight_kg": 90, "reps": 8},
+                            {"weight_kg": 100, "reps": 5},
+                        ],
+                    },
+                    {
+                        "index": 1,
+                        "title": "Overhead Press",
+                        "exercise_template_id": "T2",
+                        "sets": [
+                            {"weight_kg": 50, "reps": 10},
+                            {"weight_kg": 50, "reps": 10},
+                        ],
+                    },
+                ],
+            },
+            {
+                "id": "w2",
+                "title": "Pull Day",
+                "start_time": "2026-05-16T18:00:00+00:00",
+                "end_time": "2026-05-16T19:00:00+00:00",
+                "exercises": [
+                    {
+                        "index": 0,
+                        "title": "Deadlift",
+                        "exercise_template_id": "T3",
+                        "sets": [{"weight_kg": 140, "reps": 5}],
+                    },
+                ],
+            },
+            {
+                "id": "w3",
+                "title": "Old workout",
+                "start_time": "2026-04-01T08:00:00+00:00",
+                "end_time": "2026-04-01T08:45:00+00:00",
+                "exercises": [
+                    {
+                        "index": 0,
+                        "title": "Squat",
+                        "exercise_template_id": "T4",
+                        "sets": [{"weight_kg": 100, "reps": 5}],
+                    },
+                ],
+            },
+        ]
+    }
+
+
+@pytest.fixture
+def workout_count_fixture() -> dict[str, int]:
+    return {"workout_count": 42}
+
+
+@pytest.fixture
+def user_fixture() -> dict[str, Any]:
+    return {
+        "data": {
+            "id": "abc",
+            "name": "Hudson",
+            "url": "https://hevy.com/hudson",
+        }
+    }
+
+
+@pytest.fixture
+def measurements_fixture() -> dict[str, Any]:
+    return {
+        "body_measurements": [
+            {
+                "date": "2026-05-15",
+                "weight_kg": 82.0,
+                "fat_percent": 18.0,
+                "lean_mass_kg": 65.0,
+            },
+            {
+                "date": "2026-05-10",
+                "weight_kg": 82.5,
+                "fat_percent": 18.2,
+                "lean_mass_kg": 64.8,
+            },
+        ]
+    }

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,137 @@
+"""Tests for HevyApiClient (mocked aiohttp session)."""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import aiohttp
+import pytest
+
+from custom_components.hevy.api import (
+    HevyApiClient,
+    HevyApiClientAuthenticationError,
+    HevyApiClientCommunicationError,
+    HevyApiClientError,
+)
+
+
+def _build_response(*, status: int = 200, json_payload: Any = None) -> MagicMock:
+    """Build a mock aiohttp response."""
+    response = MagicMock()
+    response.status = status
+    response.json = AsyncMock(return_value=json_payload or {})
+    response.raise_for_status = MagicMock()
+    if status >= 400 and status not in (401, 403):
+        response.raise_for_status.side_effect = aiohttp.ClientResponseError(
+            request_info=MagicMock(),
+            history=(),
+            status=status,
+        )
+    return response
+
+
+def _build_session(response: MagicMock) -> MagicMock:
+    session = MagicMock(spec=aiohttp.ClientSession)
+    session.request = AsyncMock(return_value=response)
+    return session
+
+
+@pytest.mark.asyncio
+class TestEndpointDispatch:
+    async def test_workout_count_hits_count_endpoint(self) -> None:
+        response = _build_response(json_payload={"workout_count": 7})
+        session = _build_session(response)
+        client = HevyApiClient(api_key="key", session=session)
+
+        result = await client.async_get_workout_count()
+
+        assert result == {"workout_count": 7}
+        kwargs = session.request.await_args.kwargs
+        assert kwargs["method"] == "get"
+        assert kwargs["url"].endswith("/workouts/count")
+        assert kwargs["headers"]["api-key"] == "key"
+
+    async def test_workouts_passes_pagination_params(self) -> None:
+        response = _build_response(json_payload={"workouts": []})
+        session = _build_session(response)
+        client = HevyApiClient(api_key="key", session=session)
+
+        await client.async_get_workouts(page=2, page_size=5)
+
+        kwargs = session.request.await_args.kwargs
+        assert kwargs["params"] == {"page": 2, "pageSize": 5}
+        assert kwargs["url"].endswith("/workouts")
+
+    async def test_user_info_endpoint(self) -> None:
+        response = _build_response(json_payload={"data": {"id": "x"}})
+        session = _build_session(response)
+        client = HevyApiClient(api_key="key", session=session)
+
+        await client.async_get_user_info()
+
+        assert session.request.await_args.kwargs["url"].endswith("/user/info")
+
+    async def test_body_measurements_passes_pagination(self) -> None:
+        response = _build_response(json_payload={"body_measurements": []})
+        session = _build_session(response)
+        client = HevyApiClient(api_key="key", session=session)
+
+        await client.async_get_body_measurements(page=3, page_size=10)
+
+        kwargs = session.request.await_args.kwargs
+        assert kwargs["params"] == {"page": 3, "pageSize": 10}
+        assert kwargs["url"].endswith("/body_measurements")
+
+
+@pytest.mark.asyncio
+class TestErrorHandling:
+    async def test_401_raises_authentication_error(self) -> None:
+        response = _build_response(status=401)
+        session = _build_session(response)
+        client = HevyApiClient(api_key="bad", session=session)
+
+        with pytest.raises(HevyApiClientAuthenticationError):
+            await client.async_get_workout_count()
+
+    async def test_403_raises_authentication_error(self) -> None:
+        response = _build_response(status=403)
+        session = _build_session(response)
+        client = HevyApiClient(api_key="bad", session=session)
+
+        with pytest.raises(HevyApiClientAuthenticationError):
+            await client.async_get_workout_count()
+
+    async def test_500_raises_communication_error(self) -> None:
+        response = _build_response(status=500)
+        session = _build_session(response)
+        client = HevyApiClient(api_key="key", session=session)
+
+        with pytest.raises(HevyApiClientCommunicationError):
+            await client.async_get_workout_count()
+
+    async def test_timeout_raises_communication_error(self) -> None:
+        session = MagicMock(spec=aiohttp.ClientSession)
+        session.request = AsyncMock(side_effect=TimeoutError("boom"))
+        client = HevyApiClient(api_key="key", session=session)
+
+        with pytest.raises(HevyApiClientCommunicationError):
+            await client.async_get_workout_count()
+
+    async def test_client_error_raises_communication_error(self) -> None:
+        session = MagicMock(spec=aiohttp.ClientSession)
+        session.request = AsyncMock(
+            side_effect=aiohttp.ClientConnectionError("network down")
+        )
+        client = HevyApiClient(api_key="key", session=session)
+
+        with pytest.raises(HevyApiClientCommunicationError):
+            await client.async_get_workout_count()
+
+    async def test_unexpected_exception_wrapped(self) -> None:
+        session = MagicMock(spec=aiohttp.ClientSession)
+        session.request = AsyncMock(side_effect=ValueError("weird"))
+        client = HevyApiClient(api_key="key", session=session)
+
+        with pytest.raises(HevyApiClientError):
+            await client.async_get_workout_count()

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -1,0 +1,260 @@
+"""Tests for HevyDataUpdateCoordinator pure helpers and state builder."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+import pytest
+
+from custom_components.hevy.coordinator import (
+    _compute_streaks,
+    _set_volume_kg,
+    _workout_duration_seconds,
+)
+
+TODAY = datetime(2026, 5, 17, tzinfo=UTC).date()
+
+
+class TestSetVolumeKg:
+    def test_normal_set(self) -> None:
+        assert _set_volume_kg({"weight_kg": 100, "reps": 10}) == 1000.0
+
+    def test_none_weight_returns_zero(self) -> None:
+        assert _set_volume_kg({"weight_kg": None, "reps": 10}) == 0.0
+
+    def test_none_reps_returns_zero(self) -> None:
+        assert _set_volume_kg({"weight_kg": 50, "reps": None}) == 0.0
+
+    def test_empty_set_returns_zero(self) -> None:
+        assert _set_volume_kg({}) == 0.0
+
+    def test_float_weight_supported(self) -> None:
+        assert _set_volume_kg({"weight_kg": 12.5, "reps": 8}) == 100.0
+
+
+class TestWorkoutDurationSeconds:
+    def test_valid_pair(self) -> None:
+        record = {
+            "start_time": datetime(2026, 5, 17, 10, 0, tzinfo=UTC),
+            "_end_time_raw": "2026-05-17T11:30:00+00:00",
+        }
+        assert _workout_duration_seconds(record) == 5400.0
+
+    def test_missing_start_or_end(self) -> None:
+        assert (
+            _workout_duration_seconds({"start_time": None, "_end_time_raw": None})
+            == 0.0
+        )
+
+    def test_invalid_end_returns_zero(self) -> None:
+        record = {
+            "start_time": datetime(2026, 5, 17, 10, 0, tzinfo=UTC),
+            "_end_time_raw": "not-a-date",
+        }
+        assert _workout_duration_seconds(record) == 0.0
+
+    def test_negative_duration_clamped(self) -> None:
+        record = {
+            "start_time": datetime(2026, 5, 17, 12, 0, tzinfo=UTC),
+            "_end_time_raw": "2026-05-17T10:00:00+00:00",
+        }
+        assert _workout_duration_seconds(record) == 0.0
+
+
+class TestComputeStreaks:
+    def test_three_consecutive_including_today(self) -> None:
+        dates = {TODAY, TODAY - timedelta(days=1), TODAY - timedelta(days=2)}
+        assert _compute_streaks(dates, TODAY) == (3, 3)
+
+    def test_streak_starting_yesterday(self) -> None:
+        dates = {TODAY - timedelta(days=1), TODAY - timedelta(days=2)}
+        assert _compute_streaks(dates, TODAY) == (2, 2)
+
+    def test_gap_breaks_current_streak(self) -> None:
+        dates = {
+            TODAY - timedelta(days=1),
+            TODAY - timedelta(days=3),
+            TODAY - timedelta(days=4),
+        }
+        assert _compute_streaks(dates, TODAY) == (1, 2)
+
+    def test_stale_last_workout_zero_current(self) -> None:
+        dates = {TODAY - timedelta(days=5), TODAY - timedelta(days=6)}
+        assert _compute_streaks(dates, TODAY) == (0, 2)
+
+    def test_empty(self) -> None:
+        assert _compute_streaks(set(), TODAY) == (0, 0)
+
+    def test_single_workout_today(self) -> None:
+        assert _compute_streaks({TODAY}, TODAY) == (1, 1)
+
+
+@pytest.mark.usefixtures("freeze_coordinator_clock")
+class TestBuildState:
+    def test_volume_aggregates(
+        self,
+        coordinator: Any,
+        workout_count_fixture: dict,
+        workouts_fixture: dict,
+        user_fixture: dict,
+        measurements_fixture: dict,
+    ) -> None:
+        state = coordinator._build_state(
+            workout_count_fixture,
+            workouts_fixture,
+            user_fixture,
+            measurements_fixture,
+        )
+        assert state["volume_today_kg"] == pytest.approx(3020.0)
+        assert state["volume_week_kg"] == pytest.approx(3720.0)
+        assert state["volume_month_kg"] == pytest.approx(3720.0)
+        assert state["volume_year_kg"] == pytest.approx(4220.0)
+
+    def test_duration_aggregates(
+        self,
+        coordinator: Any,
+        workout_count_fixture: dict,
+        workouts_fixture: dict,
+        user_fixture: dict,
+        measurements_fixture: dict,
+    ) -> None:
+        state = coordinator._build_state(
+            workout_count_fixture,
+            workouts_fixture,
+            user_fixture,
+            measurements_fixture,
+        )
+        assert state["duration_today_min"] == pytest.approx(75.0)
+        assert state["duration_week_min"] == pytest.approx(135.0)
+        assert state["duration_month_min"] == pytest.approx(135.0)
+
+    def test_workout_counts(
+        self,
+        coordinator: Any,
+        workout_count_fixture: dict,
+        workouts_fixture: dict,
+        user_fixture: dict,
+        measurements_fixture: dict,
+    ) -> None:
+        state = coordinator._build_state(
+            workout_count_fixture,
+            workouts_fixture,
+            user_fixture,
+            measurements_fixture,
+        )
+        assert state["today_count"] == 1
+        assert state["week_count"] == 2
+        assert state["month_count"] == 2
+        assert state["year_count"] == 3
+        assert state["workout_count"] == 42
+
+    def test_streak_from_workouts(
+        self,
+        coordinator: Any,
+        workout_count_fixture: dict,
+        workouts_fixture: dict,
+        user_fixture: dict,
+        measurements_fixture: dict,
+    ) -> None:
+        state = coordinator._build_state(
+            workout_count_fixture,
+            workouts_fixture,
+            user_fixture,
+            measurements_fixture,
+        )
+        assert state["current_streak_days"] == 2
+        assert state["longest_streak_days"] == 2
+
+    def test_variety_window(
+        self,
+        coordinator: Any,
+        workout_count_fixture: dict,
+        workouts_fixture: dict,
+        user_fixture: dict,
+        measurements_fixture: dict,
+    ) -> None:
+        state = coordinator._build_state(
+            workout_count_fixture,
+            workouts_fixture,
+            user_fixture,
+            measurements_fixture,
+        )
+        assert state["unique_exercises_7d"] == 3
+        # T4 from April 1st is >30d before May 17 → excluded from 30d window
+        assert state["unique_exercises_30d"] == 3
+
+    def test_user_and_measurement_extracted(
+        self,
+        coordinator: Any,
+        workout_count_fixture: dict,
+        workouts_fixture: dict,
+        user_fixture: dict,
+        measurements_fixture: dict,
+    ) -> None:
+        state = coordinator._build_state(
+            workout_count_fixture,
+            workouts_fixture,
+            user_fixture,
+            measurements_fixture,
+        )
+        assert state["user"]["name"] == "Hudson"
+        assert state["latest_measurement"]["date"] == "2026-05-15"
+        assert state["latest_measurement"]["weight_kg"] == pytest.approx(82.0)
+
+    def test_last_workout_summary(
+        self,
+        coordinator: Any,
+        workout_count_fixture: dict,
+        workouts_fixture: dict,
+        user_fixture: dict,
+        measurements_fixture: dict,
+    ) -> None:
+        state = coordinator._build_state(
+            workout_count_fixture,
+            workouts_fixture,
+            user_fixture,
+            measurements_fixture,
+        )
+        lw = state["last_workout"]
+        assert lw["title"] == "Push Day"
+        assert lw["volume_kg"] == pytest.approx(3020.0)
+        assert lw["exercise_count"] == 2
+        assert lw["total_reps"] == 43
+        assert lw["duration_seconds"] == pytest.approx(4500.0)
+
+
+@pytest.mark.usefixtures("freeze_coordinator_clock")
+class TestBuildStateDegraded:
+    def test_user_and_measurements_none_does_not_crash(
+        self,
+        coordinator: Any,
+        workout_count_fixture: dict,
+        workouts_fixture: dict,
+    ) -> None:
+        state = coordinator._build_state(
+            workout_count_fixture, workouts_fixture, None, None
+        )
+        assert state["user"] == {}
+        assert state["latest_measurement"] is None
+        # Volume/duration still computed from required workouts payload.
+        assert state["volume_today_kg"] == pytest.approx(3020.0)
+
+    def test_empty_workouts(
+        self,
+        coordinator: Any,
+        user_fixture: dict,
+        measurements_fixture: dict,
+    ) -> None:
+        state = coordinator._build_state(
+            {"workout_count": 0},
+            {"workouts": []},
+            user_fixture,
+            measurements_fixture,
+        )
+        assert state["today_count"] == 0
+        assert state["current_streak_days"] == 0
+        assert state["last_workout"] is None
+        assert state["unique_exercises_7d"] == 0
+        # Latest measurement still surfaces even when no workouts.
+        assert state["latest_measurement"]["date"] == "2026-05-15"


### PR DESCRIPTION
Follow-up to #75 (already merged).

## What
- 34 pytest tests covering coordinator helpers, `_build_state` golden + degraded paths, and HevyApiClient error handling.
- Lightweight HA stubs in `conftest.py` (no `pytest-homeassistant-custom-component` dependency).
- Fix latent bug in `api.py`: broad `except Exception` swallowed `HevyApiClientAuthenticationError` and re-wrapped it as generic `HevyApiClientError`, defeating the coordinator's reauth path. Added explicit `except HevyApiClientError: raise` before the catch-all.
- New `Test` GitHub Actions workflow runs pytest on push/PR.
- `.ruff.toml`: per-file-ignores for `tests/**`.

## Test plan
- [x] `pytest tests/` 34/34 passing locally
- [x] `ruff check .` passes
- [x] `ruff format . --check` passes
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test suite with pytest framework and automated testing pipeline for continuous integration.

* **Chores**
  * Added test dependencies configuration and linting rules.

* **Bug Fixes**
  * Improved API error handling to properly propagate authentication and communication errors.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hudsonbrendon/HA-hevy/pull/76?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->