### PR TITLE
test: 68 new tests covering sensors, binary_sensor, entities

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import sys
 import types
+from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
@@ -31,12 +32,90 @@ class _StubDataUpdateCoordinator:
         self.update_interval = update_interval
 
 
+class _StubCoordinatorEntity:
+    """Minimal stand-in for CoordinatorEntity.
+
+    Generic subscript like CoordinatorEntity[HevyDataUpdateCoordinator] is
+    supported via __class_getitem__ so the import works at class-definition
+    time.
+    """
+
+    def __init__(self, coordinator: Any) -> None:
+        self.coordinator = coordinator
+
+    def __class_getitem__(cls, _item: Any) -> type:
+        return cls
+
+
 class _StubUpdateFailed(Exception):
     """Stub for UpdateFailed."""
 
 
 class _StubConfigEntryAuthFailed(Exception):
     """Stub for ConfigEntryAuthFailed."""
+
+
+class _StubEntityCategory:
+    DIAGNOSTIC = "diagnostic"
+    CONFIG = "config"
+
+
+class _StubBinarySensorDeviceClass:
+    MOTION = "motion"
+    OCCUPANCY = "occupancy"
+
+
+class _StubSensorDeviceClass:
+    WEIGHT = "weight"
+    DURATION = "duration"
+    TIMESTAMP = "timestamp"
+
+
+class _StubSensorStateClass:
+    MEASUREMENT = "measurement"
+    TOTAL_INCREASING = "total_increasing"
+
+
+class _StubUnitOfMass:
+    KILOGRAMS = "kg"
+    POUNDS = "lb"
+
+
+class _StubUnitOfTime:
+    MINUTES = "min"
+    SECONDS = "s"
+
+
+@dataclass(kw_only=True)
+class _StubBaseDescription:
+    """Dataclass base mirroring HA's *EntityDescription so subclasses compose.
+
+    Real HA descriptions use kw_only=True dataclasses; mirroring that lets the
+    @dataclass decorator on HevySensorEntityDescription/etc. merge fields
+    cleanly without ordering errors.
+    """
+
+    key: str = ""
+    translation_key: str | None = None
+    icon: str | None = None
+    name: str | None = None
+    device_class: Any = None
+    state_class: Any = None
+    native_unit_of_measurement: str | None = None
+    entity_category: Any = None
+
+
+class _StubSensorEntity:
+    pass
+
+
+class _StubBinarySensorEntity:
+    pass
+
+
+def _device_info(**kwargs: Any) -> dict[str, Any]:
+    """Stand-in for homeassistant.helpers.device_registry.DeviceInfo."""
+    return dict(kwargs)
 
 
 def _install_ha_stubs() -> None:
@@ -67,18 +146,44 @@ def _install_ha_stubs() -> None:
         "homeassistant.helpers.update_coordinator",
         DataUpdateCoordinator=_StubDataUpdateCoordinator,
         UpdateFailed=_StubUpdateFailed,
+        CoordinatorEntity=_StubCoordinatorEntity,
+    )
+    _mod(
+        "homeassistant.helpers.device_registry",
+        DeviceInfo=_device_info,
+    )
+    _mod(
+        "homeassistant.helpers.entity",
+        EntityCategory=_StubEntityCategory,
     )
     _mod("homeassistant.core", HomeAssistant=object)
     _mod("homeassistant.config_entries", ConfigEntry=object)
     _mod(
         "homeassistant.const",
         Platform=types.SimpleNamespace(SENSOR="sensor", BINARY_SENSOR="binary_sensor"),
+        PERCENTAGE="%",
+        UnitOfMass=_StubUnitOfMass,
+        UnitOfTime=_StubUnitOfTime,
     )
     _mod(
         "homeassistant.helpers.aiohttp_client",
         async_get_clientsession=lambda _hass: None,
     )
     _mod("homeassistant.loader", async_get_integration=lambda *a, **k: None)
+    _pkg("homeassistant.components")
+    _mod(
+        "homeassistant.components.sensor",
+        SensorEntity=_StubSensorEntity,
+        SensorEntityDescription=_StubBaseDescription,
+        SensorDeviceClass=_StubSensorDeviceClass,
+        SensorStateClass=_StubSensorStateClass,
+    )
+    _mod(
+        "homeassistant.components.binary_sensor",
+        BinarySensorEntity=_StubBinarySensorEntity,
+        BinarySensorEntityDescription=_StubBaseDescription,
+        BinarySensorDeviceClass=_StubBinarySensorDeviceClass,
+    )
 
 
 _install_ha_stubs()
@@ -103,7 +208,15 @@ def _register_hevy_package() -> None:
     hevy_pkg.__path__ = [str(pkg_root / "hevy")]
     sys.modules["custom_components.hevy"] = hevy_pkg
 
-    for submodule in ("const", "api", "data", "coordinator"):
+    for submodule in (
+        "const",
+        "api",
+        "data",
+        "coordinator",
+        "entity",
+        "sensor",
+        "binary_sensor",
+    ):
         spec = importlib.util.spec_from_file_location(
             f"custom_components.hevy.{submodule}",
             pkg_root / "hevy" / f"{submodule}.py",
@@ -140,6 +253,13 @@ def freeze_coordinator_clock(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(coord_mod, "datetime", _FrozenDatetime)
 
 
+class _StubConfigEntry:
+    """Minimal stand-in for ConfigEntry used by entity unique_id helpers."""
+
+    def __init__(self, entry_id: str = "entry-123") -> None:
+        self.entry_id = entry_id
+
+
 @pytest.fixture
 def coordinator() -> Any:
     """Build a coordinator instance without running __init__ (no HA needed)."""
@@ -147,6 +267,19 @@ def coordinator() -> Any:
 
     coord = HevyDataUpdateCoordinator.__new__(HevyDataUpdateCoordinator)
     coord.name = "Hudson"
+    return coord
+
+
+@pytest.fixture
+def entity_coordinator() -> Any:
+    """A coordinator wired with `data`, `config_entry`, and update success flag."""
+    from custom_components.hevy.coordinator import HevyDataUpdateCoordinator
+
+    coord = HevyDataUpdateCoordinator.__new__(HevyDataUpdateCoordinator)
+    coord.name = "Hudson"
+    coord.config_entry = _StubConfigEntry()
+    coord.last_update_success = True
+    coord.data = {}
     return coord
 
 

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -1,0 +1,95 @@
+"""Tests for binary_sensor is_on_fn lambdas + HevyBinarySensor entity."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from custom_components.hevy.binary_sensor import (
+    WORKOUT_TODAY_DESCRIPTION,
+    WORKOUT_WEEK_DESCRIPTION,
+    HevyBinarySensor,
+)
+
+
+def _state(workouts: dict[str, dict]) -> dict[str, Any]:
+    """Helper to build a coordinator state with given workouts dict."""
+    return {"workouts": workouts}
+
+
+@pytest.fixture
+def today_utc() -> datetime:
+    """Real datetime.now is used by binary_sensor lambdas — anchor 'today'."""
+    return datetime.now(tz=UTC)
+
+
+class TestWorkoutTodayLambda:
+    def test_true_when_workout_today(self, today_utc: datetime) -> None:
+        state = _state({"w1": {"id": "w1", "start_time": today_utc}})
+        assert WORKOUT_TODAY_DESCRIPTION.is_on_fn(state) is True
+
+    def test_false_when_only_yesterday(self, today_utc: datetime) -> None:
+        yesterday = today_utc - timedelta(days=1)
+        state = _state({"w1": {"id": "w1", "start_time": yesterday}})
+        assert WORKOUT_TODAY_DESCRIPTION.is_on_fn(state) is False
+
+    def test_false_when_no_workouts(self) -> None:
+        assert WORKOUT_TODAY_DESCRIPTION.is_on_fn(_state({})) is False
+
+    def test_false_when_workouts_key_missing(self) -> None:
+        assert WORKOUT_TODAY_DESCRIPTION.is_on_fn({}) is False
+
+    def test_workout_without_start_time_uses_default(self) -> None:
+        # Missing start_time defaults to datetime.min (epoch-ish) → never == today
+        state = _state({"w1": {"id": "w1"}})
+        assert WORKOUT_TODAY_DESCRIPTION.is_on_fn(state) is False
+
+
+class TestWorkoutWeekLambda:
+    def test_true_when_within_seven_days(self, today_utc: datetime) -> None:
+        recent = today_utc - timedelta(days=3)
+        state = _state({"w1": {"id": "w1", "start_time": recent}})
+        assert WORKOUT_WEEK_DESCRIPTION.is_on_fn(state) is True
+
+    def test_false_when_eight_days_old(self, today_utc: datetime) -> None:
+        old = today_utc - timedelta(days=8)
+        state = _state({"w1": {"id": "w1", "start_time": old}})
+        assert WORKOUT_WEEK_DESCRIPTION.is_on_fn(state) is False
+
+    def test_today_counts_as_within_week(self, today_utc: datetime) -> None:
+        state = _state({"w1": {"id": "w1", "start_time": today_utc}})
+        assert WORKOUT_WEEK_DESCRIPTION.is_on_fn(state) is True
+
+    def test_empty_workouts(self) -> None:
+        assert WORKOUT_WEEK_DESCRIPTION.is_on_fn(_state({})) is False
+
+
+class TestHevyBinarySensorEntity:
+    def test_is_on_dispatches_to_description_lambda(self, today_utc: datetime) -> None:
+        coord = MagicMock()
+        coord.data = _state({"w1": {"id": "w1", "start_time": today_utc}})
+
+        sensor = HevyBinarySensor.__new__(HevyBinarySensor)
+        sensor.coordinator = coord
+        sensor.entity_description = WORKOUT_TODAY_DESCRIPTION
+
+        assert sensor.is_on is True
+
+    def test_is_on_false_for_empty(self) -> None:
+        coord = MagicMock()
+        coord.data = _state({})
+
+        sensor = HevyBinarySensor.__new__(HevyBinarySensor)
+        sensor.coordinator = coord
+        sensor.entity_description = WORKOUT_WEEK_DESCRIPTION
+
+        assert sensor.is_on is False
+
+    def test_description_metadata(self) -> None:
+        # The MOTION device class is intentional (occupancy-style trigger).
+        assert WORKOUT_TODAY_DESCRIPTION.key == "workout_today"
+        assert WORKOUT_TODAY_DESCRIPTION.translation_key == "workout_today"
+        assert WORKOUT_WEEK_DESCRIPTION.key == "workout_this_week"

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -1,0 +1,216 @@
+"""Tests for HevyEntity / HevyWorkoutEntity / HevySensor / HevyExerciseSensor."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+
+import pytest
+
+from custom_components.hevy.entity import HevyEntity, HevyWorkoutEntity
+from custom_components.hevy.sensor import (
+    WORKOUT_COUNT_DESCRIPTION,
+    HevyExerciseSensor,
+    HevySensor,
+    HevyWorkoutDateSensor,
+)
+
+
+@pytest.fixture
+def populated_coordinator(entity_coordinator: Any) -> Any:
+    entity_coordinator.data = {
+        "workout_count": 42,
+        "workouts": {
+            "w1": {
+                "id": "w1",
+                "title": "Push Day",
+                "start_time": datetime(2026, 5, 17, 9, 0, tzinfo=UTC),
+                "exercises": {
+                    "0_Bench Press": {
+                        "title": "Bench Press",
+                        "sets": 3,
+                        "total_reps": 23,
+                        "volume_kg": 2020.0,
+                        "max_weight_kg": 100.0,
+                    },
+                },
+            }
+        },
+    }
+    return entity_coordinator
+
+
+class TestHevyEntity:
+    def test_unique_id_uses_entry_id(self, populated_coordinator: Any) -> None:
+        ent = HevyEntity(populated_coordinator)
+        assert ent._attr_unique_id == "entry-123"
+
+    def test_device_info_identifiers_include_name_and_entry_id(
+        self, populated_coordinator: Any
+    ) -> None:
+        ent = HevyEntity(populated_coordinator)
+        info = ent._attr_device_info
+        assert info["name"] == "Hudson"
+        assert info["manufacturer"] == "Hevy"
+        identifiers = info["identifiers"]
+        assert ("hevy", "Hudson_entry-123") in identifiers
+
+
+class TestHevyWorkoutEntity:
+    def test_workout_data_reads_from_coordinator(
+        self, populated_coordinator: Any
+    ) -> None:
+        ent = HevyWorkoutEntity(populated_coordinator, "w1")
+        assert ent.workout_data["title"] == "Push Day"
+
+    def test_workout_data_empty_for_unknown_id(
+        self, populated_coordinator: Any
+    ) -> None:
+        ent = HevyWorkoutEntity(populated_coordinator, "missing")
+        assert ent.workout_data == {}
+
+    def test_available_true_when_workout_present(
+        self, populated_coordinator: Any
+    ) -> None:
+        ent = HevyWorkoutEntity(populated_coordinator, "w1")
+        assert ent.available is True
+
+    def test_available_false_when_workout_missing(
+        self, populated_coordinator: Any
+    ) -> None:
+        ent = HevyWorkoutEntity(populated_coordinator, "missing")
+        assert ent.available is False
+
+    def test_available_false_when_coordinator_failed(
+        self, populated_coordinator: Any
+    ) -> None:
+        populated_coordinator.last_update_success = False
+        ent = HevyWorkoutEntity(populated_coordinator, "w1")
+        assert ent.available is False
+
+    def test_device_info_carries_workout_title(
+        self, populated_coordinator: Any
+    ) -> None:
+        ent = HevyWorkoutEntity(populated_coordinator, "w1")
+        info = ent._attr_device_info
+        assert "Push Day" in info["name"]
+        assert info["model"] == "Workout"
+        # via_device links back to root device
+        assert info["via_device"] == ("hevy", "Hudson_entry-123")
+
+
+class TestHevySensor:
+    def test_native_value_invokes_description_value_fn(
+        self, populated_coordinator: Any
+    ) -> None:
+        sensor = HevySensor(populated_coordinator, WORKOUT_COUNT_DESCRIPTION)
+        assert sensor.native_value == 42
+
+    def test_unique_id_combines_entry_and_description_key(
+        self, populated_coordinator: Any
+    ) -> None:
+        sensor = HevySensor(populated_coordinator, WORKOUT_COUNT_DESCRIPTION)
+        assert sensor._attr_unique_id == "entry-123_workout_count"
+
+    def test_extra_state_attributes_none_when_no_attributes_fn(
+        self, populated_coordinator: Any
+    ) -> None:
+        sensor = HevySensor(populated_coordinator, WORKOUT_COUNT_DESCRIPTION)
+        # workout_count description has no attributes_fn
+        assert sensor.extra_state_attributes is None
+
+    def test_extra_state_attributes_strips_none_values(
+        self, populated_coordinator: Any
+    ) -> None:
+        from custom_components.hevy.sensor import USER_NAME_DESCRIPTION
+
+        # No user data → both attrs would be None → dict should be empty
+        populated_coordinator.data = {}
+        sensor = HevySensor(populated_coordinator, USER_NAME_DESCRIPTION)
+        attrs = sensor.extra_state_attributes
+        assert attrs == {}
+
+
+class TestHevyWorkoutDateSensor:
+    def test_native_value_returns_start_time(self, populated_coordinator: Any) -> None:
+        sensor = HevyWorkoutDateSensor(populated_coordinator, "w1")
+        assert sensor.native_value == datetime(2026, 5, 17, 9, 0, tzinfo=UTC)
+
+    def test_native_value_none_when_workout_missing(
+        self, populated_coordinator: Any
+    ) -> None:
+        sensor = HevyWorkoutDateSensor(populated_coordinator, "w1")
+        # Wipe workouts after construction
+        populated_coordinator.data = {"workouts": {}}
+        assert sensor.native_value is None
+
+
+class TestHevyExerciseSensor:
+    def test_native_value_returns_max_weight(self, populated_coordinator: Any) -> None:
+        sensor = HevyExerciseSensor(
+            coordinator=populated_coordinator,
+            workout_id="w1",
+            exercise_key="0_Bench Press",
+        )
+        assert sensor.native_value == 100.0
+
+    def test_native_value_none_when_unavailable(
+        self, populated_coordinator: Any
+    ) -> None:
+        sensor = HevyExerciseSensor(
+            coordinator=populated_coordinator,
+            workout_id="w1",
+            exercise_key="0_Bench Press",
+        )
+        populated_coordinator.last_update_success = False
+        assert sensor.native_value is None
+
+    def test_native_value_none_when_exercise_key_missing(
+        self, populated_coordinator: Any
+    ) -> None:
+        sensor = HevyExerciseSensor(
+            coordinator=populated_coordinator,
+            workout_id="w1",
+            exercise_key="99_Ghost Exercise",
+        )
+        assert sensor.native_value is None
+
+    def test_extra_state_attributes(self, populated_coordinator: Any) -> None:
+        sensor = HevyExerciseSensor(
+            coordinator=populated_coordinator,
+            workout_id="w1",
+            exercise_key="0_Bench Press",
+        )
+        attrs = sensor.extra_state_attributes
+        assert attrs["sets"] == 3
+        assert attrs["total_reps"] == 23
+        assert attrs["volume_kg"] == 2020.0
+
+    def test_extra_state_attributes_empty_when_unavailable(
+        self, populated_coordinator: Any
+    ) -> None:
+        sensor = HevyExerciseSensor(
+            coordinator=populated_coordinator,
+            workout_id="w1",
+            exercise_key="0_Bench Press",
+        )
+        populated_coordinator.last_update_success = False
+        assert sensor.extra_state_attributes == {}
+
+    def test_name_uses_exercise_title(self, populated_coordinator: Any) -> None:
+        sensor = HevyExerciseSensor(
+            coordinator=populated_coordinator,
+            workout_id="w1",
+            exercise_key="0_Bench Press",
+        )
+        assert sensor._attr_name == "Bench Press"
+
+    def test_name_defaults_when_exercise_missing(
+        self, populated_coordinator: Any
+    ) -> None:
+        sensor = HevyExerciseSensor(
+            coordinator=populated_coordinator,
+            workout_id="w1",
+            exercise_key="99_Ghost",
+        )
+        assert sensor._attr_name == "Unknown Exercise"

--- a/tests/test_sensor_descriptions.py
+++ b/tests/test_sensor_descriptions.py
@@ -1,0 +1,243 @@
+"""Tests for the HevySensorEntityDescription value_fn / attributes_fn lambdas.
+
+Descriptions are pure functions over the coordinator state dict, so they can
+be invoked directly without instantiating the HevySensor entity.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+
+import pytest
+
+from custom_components.hevy.sensor import (
+    ALL_DESCRIPTIONS,
+    BODY_FAT_DESCRIPTION,
+    BODY_WEIGHT_DESCRIPTION,
+    DURATION_AGGREGATE_DESCRIPTIONS,
+    LAST_WORKOUT_DURATION_DESCRIPTION,
+    LAST_WORKOUT_START_DESCRIPTION,
+    LAST_WORKOUT_TITLE_DESCRIPTION,
+    LAST_WORKOUT_VOLUME_DESCRIPTION,
+    LEAN_MASS_DESCRIPTION,
+    MONTH_COUNT_DESCRIPTION,
+    STREAK_DESCRIPTIONS,
+    TODAY_COUNT_DESCRIPTION,
+    USER_NAME_DESCRIPTION,
+    VARIETY_DESCRIPTIONS,
+    VOLUME_AGGREGATE_DESCRIPTIONS,
+    WEEK_COUNT_DESCRIPTION,
+    WORKOUT_COUNT_DESCRIPTION,
+    YEAR_COUNT_DESCRIPTION,
+)
+
+
+@pytest.fixture
+def full_state() -> dict[str, Any]:
+    return {
+        "workout_count": 42,
+        "today_count": 1,
+        "week_count": 3,
+        "month_count": 12,
+        "year_count": 150,
+        "last_workout": {
+            "title": "Push Day",
+            "start_time": datetime(2026, 5, 17, 9, 0, tzinfo=UTC),
+            "duration_seconds": 4500.0,
+            "volume_kg": 3020.0,
+            "exercise_count": 5,
+            "total_reps": 80,
+        },
+        "latest_measurement": {
+            "date": "2026-05-15",
+            "weight_kg": 82.0,
+            "fat_percent": 18.5,
+            "lean_mass_kg": 65.0,
+        },
+        "user": {
+            "id": "u1",
+            "name": "Hudson",
+            "url": "https://hevy.com/hudson",
+        },
+        "volume_today_kg": 3020.123,
+        "volume_week_kg": 9000.0,
+        "volume_month_kg": 18000.0,
+        "volume_year_kg": 100000.0,
+        "duration_today_min": 75.0,
+        "duration_week_min": 240.0,
+        "duration_month_min": 900.0,
+        "current_streak_days": 5,
+        "longest_streak_days": 14,
+        "unique_exercises_7d": 12,
+        "unique_exercises_30d": 28,
+    }
+
+
+class TestCountValueFns:
+    def test_workout_count(self, full_state: dict) -> None:
+        assert WORKOUT_COUNT_DESCRIPTION.value_fn(full_state) == 42
+
+    def test_today_count_default_zero(self) -> None:
+        assert TODAY_COUNT_DESCRIPTION.value_fn({}) == 0
+
+    def test_week_month_year(self, full_state: dict) -> None:
+        assert WEEK_COUNT_DESCRIPTION.value_fn(full_state) == 3
+        assert MONTH_COUNT_DESCRIPTION.value_fn(full_state) == 12
+        assert YEAR_COUNT_DESCRIPTION.value_fn(full_state) == 150
+
+
+class TestLastWorkoutValueFns:
+    def test_title(self, full_state: dict) -> None:
+        assert LAST_WORKOUT_TITLE_DESCRIPTION.value_fn(full_state) == "Push Day"
+
+    def test_title_none_when_no_last_workout(self) -> None:
+        assert LAST_WORKOUT_TITLE_DESCRIPTION.value_fn({}) is None
+
+    def test_title_none_when_last_workout_none(self) -> None:
+        assert LAST_WORKOUT_TITLE_DESCRIPTION.value_fn({"last_workout": None}) is None
+
+    def test_start(self, full_state: dict) -> None:
+        result = LAST_WORKOUT_START_DESCRIPTION.value_fn(full_state)
+        assert result == datetime(2026, 5, 17, 9, 0, tzinfo=UTC)
+
+    def test_duration_min_converted(self, full_state: dict) -> None:
+        # 4500s / 60 = 75 min
+        assert LAST_WORKOUT_DURATION_DESCRIPTION.value_fn(full_state) == 75.0
+
+    def test_duration_none_when_zero_seconds(self) -> None:
+        state = {"last_workout": {"duration_seconds": 0}}
+        assert LAST_WORKOUT_DURATION_DESCRIPTION.value_fn(state) is None
+
+    def test_duration_none_when_missing(self) -> None:
+        assert LAST_WORKOUT_DURATION_DESCRIPTION.value_fn({}) is None
+
+    def test_volume(self, full_state: dict) -> None:
+        assert LAST_WORKOUT_VOLUME_DESCRIPTION.value_fn(full_state) == 3020.0
+
+    def test_volume_none_when_no_last_workout(self) -> None:
+        assert LAST_WORKOUT_VOLUME_DESCRIPTION.value_fn({}) is None
+
+
+class TestLastWorkoutAttributes:
+    def test_attrs_when_populated(self, full_state: dict) -> None:
+        attrs = LAST_WORKOUT_TITLE_DESCRIPTION.attributes_fn(full_state)
+        assert attrs == {"exercise_count": 5, "total_reps": 80}
+
+    def test_attrs_default_zero_when_missing(self) -> None:
+        attrs = LAST_WORKOUT_TITLE_DESCRIPTION.attributes_fn({})
+        assert attrs == {"exercise_count": 0, "total_reps": 0}
+
+
+class TestVolumeAggregates:
+    def test_round_to_one_decimal(self, full_state: dict) -> None:
+        # The volume_today description is the first in the tuple (today/week/month/year)
+        today_desc = VOLUME_AGGREGATE_DESCRIPTIONS[0]
+        assert today_desc.key == "volume_today_kg"
+        assert today_desc.value_fn(full_state) == pytest.approx(3020.1)
+
+    def test_default_zero_when_missing(self) -> None:
+        for desc in VOLUME_AGGREGATE_DESCRIPTIONS:
+            assert desc.value_fn({}) == 0
+
+    def test_all_periods_present(self) -> None:
+        keys = [d.key for d in VOLUME_AGGREGATE_DESCRIPTIONS]
+        assert keys == [
+            "volume_today_kg",
+            "volume_week_kg",
+            "volume_month_kg",
+            "volume_year_kg",
+        ]
+
+
+class TestDurationAggregates:
+    def test_returns_rounded_minutes(self, full_state: dict) -> None:
+        today_desc = DURATION_AGGREGATE_DESCRIPTIONS[0]
+        assert today_desc.key == "duration_today_min"
+        assert today_desc.value_fn(full_state) == 75.0
+
+    def test_no_year_aggregate(self) -> None:
+        # Only today/week/month exposed for duration (year would be misleading)
+        keys = [d.key for d in DURATION_AGGREGATE_DESCRIPTIONS]
+        assert "duration_year_min" not in keys
+        assert len(DURATION_AGGREGATE_DESCRIPTIONS) == 3
+
+
+class TestStreaks:
+    def test_current_and_longest(self, full_state: dict) -> None:
+        current, longest = STREAK_DESCRIPTIONS
+        assert current.value_fn(full_state) == 5
+        assert longest.value_fn(full_state) == 14
+
+    def test_default_zero(self) -> None:
+        for desc in STREAK_DESCRIPTIONS:
+            assert desc.value_fn({}) == 0
+
+
+class TestVariety:
+    def test_values(self, full_state: dict) -> None:
+        seven, thirty = VARIETY_DESCRIPTIONS
+        assert seven.value_fn(full_state) == 12
+        assert thirty.value_fn(full_state) == 28
+
+
+class TestBodyMeasurementDescriptions:
+    def test_weight(self, full_state: dict) -> None:
+        assert BODY_WEIGHT_DESCRIPTION.value_fn(full_state) == 82.0
+
+    def test_weight_none_when_no_measurement(self) -> None:
+        assert BODY_WEIGHT_DESCRIPTION.value_fn({}) is None
+
+    def test_weight_attrs_include_date(self, full_state: dict) -> None:
+        attrs = BODY_WEIGHT_DESCRIPTION.attributes_fn(full_state)
+        assert attrs == {"date": "2026-05-15"}
+
+    def test_weight_attrs_empty_date_when_no_measurement(self) -> None:
+        attrs = BODY_WEIGHT_DESCRIPTION.attributes_fn({})
+        assert attrs == {"date": None}
+
+    def test_fat(self, full_state: dict) -> None:
+        assert BODY_FAT_DESCRIPTION.value_fn(full_state) == 18.5
+
+    def test_lean_mass(self, full_state: dict) -> None:
+        assert LEAN_MASS_DESCRIPTION.value_fn(full_state) == 65.0
+
+
+class TestUserDescription:
+    def test_name(self, full_state: dict) -> None:
+        assert USER_NAME_DESCRIPTION.value_fn(full_state) == "Hudson"
+
+    def test_name_none_when_no_user(self) -> None:
+        assert USER_NAME_DESCRIPTION.value_fn({}) is None
+
+    def test_attrs(self, full_state: dict) -> None:
+        attrs = USER_NAME_DESCRIPTION.attributes_fn(full_state)
+        assert attrs == {
+            "user_id": "u1",
+            "profile_url": "https://hevy.com/hudson",
+        }
+
+
+class TestRegistry:
+    def test_all_descriptions_have_unique_keys(self) -> None:
+        keys = [d.key for d in ALL_DESCRIPTIONS]
+        assert len(keys) == len(set(keys)), f"duplicate keys: {keys}"
+
+    def test_all_descriptions_have_value_fn(self) -> None:
+        for desc in ALL_DESCRIPTIONS:
+            assert callable(desc.value_fn), f"{desc.key} missing value_fn"
+
+    def test_value_fns_handle_empty_state(self) -> None:
+        # No description should raise on empty state — must degrade to None/0.
+        for desc in ALL_DESCRIPTIONS:
+            result = desc.value_fn({})
+            assert result is None or isinstance(result, int | float | str), (
+                f"{desc.key} returned unexpected type: {type(result).__name__}"
+            )
+
+    def test_attributes_fns_handle_empty_state(self) -> None:
+        for desc in ALL_DESCRIPTIONS:
+            if desc.attributes_fn is None:
+                continue
+            attrs = desc.attributes_fn({})
+            assert isinstance(attrs, dict), f"{desc.key} attrs not dict"


### PR DESCRIPTION
## Summary

Bumps test coverage from 34 → **102 passing**. Adds suites for every untested entity/description path.

| File | Tests | Covers |
|---|---|---|
| `test_sensor_descriptions.py` | 35 | All `value_fn` + `attributes_fn` lambdas in sensor.py (count/last-workout/aggregates/streaks/variety/body/user) |
| `test_binary_sensor.py` | 13 | `WORKOUT_TODAY` / `WORKOUT_WEEK` lambdas + `HevyBinarySensor.is_on` |
| `test_entities.py` | 20 | `HevyEntity` device_info & unique_id, `HevyWorkoutEntity` workout_data/available/device_info, `HevySensor`, `HevyWorkoutDateSensor`, `HevyExerciseSensor` |

Also: registry-level smoke tests (no duplicate keys, all `value_fn` handle empty state, all `attributes_fn` return dicts).

## Test plan
- [x] `pytest tests/` → 102/102 passing locally in ~0.1s
- [x] `ruff check .` passes
- [x] `ruff format . --check` passes
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)