### PR TITLE
feat(phase-3): fire HA events for new & deleted workouts

### DIFF
--- a/custom_components/hevy/const.py
+++ b/custom_components/hevy/const.py
@@ -12,3 +12,6 @@ BASE_URL = "https://api.hevyapp.com/v1"
 
 DEFAULT_WORKOUTS_COUNT = 10
 DEFAULT_SCAN_INTERVAL = 60  # minutes
+
+EVENT_WORKOUT_COMPLETED = "hevy_workout_completed"
+EVENT_WORKOUT_DELETED = "hevy_workout_deleted"

--- a/custom_components/hevy/coordinator.py
+++ b/custom_components/hevy/coordinator.py
@@ -14,7 +14,13 @@ from .api import (
     HevyApiClientAuthenticationError,
     HevyApiClientError,
 )
-from .const import DEFAULT_WORKOUTS_COUNT, DOMAIN, LOGGER
+from .const import (
+    DEFAULT_WORKOUTS_COUNT,
+    DOMAIN,
+    EVENT_WORKOUT_COMPLETED,
+    EVENT_WORKOUT_DELETED,
+    LOGGER,
+)
 
 if TYPE_CHECKING:
     from homeassistant.core import HomeAssistant
@@ -40,6 +46,20 @@ def _workout_duration_seconds(workout: dict[str, Any]) -> float:
     except (TypeError, ValueError):
         return 0.0
     return max(0.0, (end - start).total_seconds())
+
+
+def _event_payload(record: dict[str, Any]) -> dict[str, Any]:
+    """Build the HA event payload for a workout record."""
+    start = record.get("start_time")
+    return {
+        "id": record.get("id"),
+        "title": record.get("title"),
+        "start_time": start.isoformat() if start else None,
+        "duration_min": round((record.get("duration_seconds") or 0) / 60, 1),
+        "volume_kg": round(record.get("volume_kg") or 0, 1),
+        "total_reps": record.get("total_reps", 0),
+        "exercise_count": record.get("exercise_count", 0),
+    }
 
 
 def _compute_streaks(workout_dates: set[date], today: date) -> tuple[int, int]:
@@ -94,6 +114,7 @@ class HevyDataUpdateCoordinator(DataUpdateCoordinator):
         )
         self.name = name
         self.data: dict[str, Any] = {}
+        self._primed = False
 
     async def _async_update_data(self) -> dict[str, Any]:
         """Update data via library."""
@@ -115,9 +136,36 @@ class HevyDataUpdateCoordinator(DataUpdateCoordinator):
         except HevyApiClientError as exception:
             raise UpdateFailed(exception) from exception
 
-        return self._build_state(
+        previous_workouts = self.data.get("workouts", {}) if self.data else {}
+        new_state = self._build_state(
             workout_count_data, workouts_data, user_data, measurements_data
         )
+        self._fire_workout_events(previous_workouts, new_state["workouts"])
+        self._primed = True
+        return new_state
+
+    def _fire_workout_events(
+        self,
+        previous: dict[str, dict[str, Any]],
+        current: dict[str, dict[str, Any]],
+    ) -> None:
+        """Fire HA events for workouts added/removed since the last poll."""
+        # First successful refresh primes the cache without firing events so
+        # the integration doesn't spam HA on startup with one event per
+        # cached workout.
+        if not self._primed:
+            return
+        for workout_id, record in current.items():
+            if workout_id not in previous:
+                self.hass.bus.async_fire(
+                    EVENT_WORKOUT_COMPLETED, _event_payload(record)
+                )
+        for workout_id, record in previous.items():
+            if workout_id not in current:
+                self.hass.bus.async_fire(
+                    EVENT_WORKOUT_DELETED,
+                    {"id": workout_id, "title": record.get("title")},
+                )
 
     def _build_state(
         self,

--- a/custom_components/hevy/manifest.json
+++ b/custom_components/hevy/manifest.json
@@ -8,5 +8,5 @@
   "documentation": "https://github.com/hudsonbrendon/HA-hevy",
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/hudsonbrendon/HA-hevy/issues",
-  "version": "0.2.0"
+  "version": "0.3.0"
 }

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -1,0 +1,137 @@
+"""Tests for HA event firing on workout add/remove."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from custom_components.hevy.const import (
+    EVENT_WORKOUT_COMPLETED,
+    EVENT_WORKOUT_DELETED,
+)
+from custom_components.hevy.coordinator import (
+    HevyDataUpdateCoordinator,
+    _event_payload,
+)
+
+
+class TestEventPayload:
+    def test_full_record(self) -> None:
+        record = {
+            "id": "w1",
+            "title": "Push Day",
+            "start_time": datetime(2026, 5, 17, 9, 0, tzinfo=UTC),
+            "duration_seconds": 4500.0,
+            "volume_kg": 3020.123,
+            "total_reps": 80,
+            "exercise_count": 5,
+        }
+        payload = _event_payload(record)
+        assert payload == {
+            "id": "w1",
+            "title": "Push Day",
+            "start_time": "2026-05-17T09:00:00+00:00",
+            "duration_min": 75.0,
+            "volume_kg": 3020.1,
+            "total_reps": 80,
+            "exercise_count": 5,
+        }
+
+    def test_missing_fields_defaults(self) -> None:
+        payload = _event_payload({"id": "w1"})
+        assert payload["id"] == "w1"
+        assert payload["title"] is None
+        assert payload["start_time"] is None
+        assert payload["duration_min"] == 0.0
+        assert payload["volume_kg"] == 0
+        assert payload["total_reps"] == 0
+        assert payload["exercise_count"] == 0
+
+    def test_none_duration_does_not_crash(self) -> None:
+        payload = _event_payload({"id": "w1", "duration_seconds": None})
+        assert payload["duration_min"] == 0.0
+
+
+@pytest.fixture
+def coord_with_bus() -> Any:
+    coord = HevyDataUpdateCoordinator.__new__(HevyDataUpdateCoordinator)
+    coord.name = "Hudson"
+    coord.hass = MagicMock()
+    coord.hass.bus = MagicMock()
+    coord._primed = True
+    return coord
+
+
+def _record(workout_id: str, title: str = "Push Day") -> dict[str, Any]:
+    return {
+        "id": workout_id,
+        "title": title,
+        "start_time": datetime(2026, 5, 17, 9, 0, tzinfo=UTC),
+        "duration_seconds": 3600,
+        "volume_kg": 1000.0,
+        "total_reps": 30,
+        "exercise_count": 3,
+    }
+
+
+class TestFireWorkoutEvents:
+    def test_new_workout_fires_completed(self, coord_with_bus: Any) -> None:
+        coord_with_bus._fire_workout_events(
+            previous={},
+            current={"w1": _record("w1")},
+        )
+        coord_with_bus.hass.bus.async_fire.assert_called_once()
+        event, payload = coord_with_bus.hass.bus.async_fire.call_args.args
+        assert event == EVENT_WORKOUT_COMPLETED
+        assert payload["id"] == "w1"
+        assert payload["title"] == "Push Day"
+
+    def test_removed_workout_fires_deleted(self, coord_with_bus: Any) -> None:
+        coord_with_bus._fire_workout_events(
+            previous={"w1": _record("w1", title="Pull Day")},
+            current={},
+        )
+        coord_with_bus.hass.bus.async_fire.assert_called_once_with(
+            EVENT_WORKOUT_DELETED, {"id": "w1", "title": "Pull Day"}
+        )
+
+    def test_unchanged_workouts_fire_nothing(self, coord_with_bus: Any) -> None:
+        same = {"w1": _record("w1")}
+        coord_with_bus._fire_workout_events(previous=same, current=same)
+        coord_with_bus.hass.bus.async_fire.assert_not_called()
+
+    def test_first_refresh_is_silent(self, coord_with_bus: Any) -> None:
+        coord_with_bus._primed = False
+        coord_with_bus._fire_workout_events(
+            previous={},
+            current={"w1": _record("w1"), "w2": _record("w2", title="Pull")},
+        )
+        coord_with_bus.hass.bus.async_fire.assert_not_called()
+
+    def test_simultaneous_new_and_deleted(self, coord_with_bus: Any) -> None:
+        coord_with_bus._fire_workout_events(
+            previous={"old": _record("old")},
+            current={"new": _record("new")},
+        )
+        calls = coord_with_bus.hass.bus.async_fire.call_args_list
+        events = sorted([c.args[0] for c in calls])
+        assert events == [EVENT_WORKOUT_COMPLETED, EVENT_WORKOUT_DELETED]
+
+    def test_multiple_new_workouts(self, coord_with_bus: Any) -> None:
+        coord_with_bus._fire_workout_events(
+            previous={},
+            current={
+                "w1": _record("w1", title="A"),
+                "w2": _record("w2", title="B"),
+                "w3": _record("w3", title="C"),
+            },
+        )
+        assert coord_with_bus.hass.bus.async_fire.call_count == 3
+        titles = {
+            c.args[1]["title"]
+            for c in coord_with_bus.hass.bus.async_fire.call_args_list
+        }
+        assert titles == {"A", "B", "C"}


### PR DESCRIPTION
Closes #72 (partial — diff-based events; `/workouts/events` endpoint deferred to a follow-up).

## What
Each coordinator refresh diffs the workouts cache against the previous poll and fires HA events:

| Event | When | Payload |
|---|---|---|
| `hevy_workout_completed` | New workout id appears | `id`, `title`, `start_time` (ISO), `duration_min`, `volume_kg`, `total_reps`, `exercise_count` |
| `hevy_workout_deleted` | Cached workout id disappears | `id`, `title` |

The first successful refresh **primes the cache silently** so HA doesn't get spammed at startup with one completed event per existing workout.

## Why this matters
Unlocks automations that previously needed template sensors + history-stat hacks:

```yaml
automation:
  - alias: Play workout playlist when training starts
    trigger:
      platform: event
      event_type: hevy_workout_completed
    action:
      - service: media_player.play_media
        ...
```

## Internals
- `coordinator._fire_workout_events(previous, current)` — pure diff, side-effect on `hass.bus.async_fire`.
- `_event_payload(record)` — builds the payload dict from a processed workout record.
- `_primed` flag set after the first successful refresh.

## Tests
9 new tests (now **111 passing** total) covering: payload shape (full + missing fields + None duration), new/deleted detection, no-op on unchanged set, silent first refresh, simultaneous new+deleted, multiple new workouts.

## Manifest
Bumped `0.2.0 → 0.3.0`.

## Test plan
- [x] `pytest tests/` 111/111 passing
- [x] `ruff check .` passes
- [x] `ruff format . --check` passes
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)