### PR TITLE
feat(phase-2): expose workouts as HA Calendar entity

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -36,6 +36,7 @@ ignore = [
     "N818",    # internal stub names mirror HA classes
     "ARG005",  # lambda stubs intentionally ignore args
     "PLC0415", # late imports needed after stub injection
+    "PLR0913", # test helper builders may take many fields by design
 ]
 
 [lint.flake8-pytest-style]

--- a/custom_components/hevy/__init__.py
+++ b/custom_components/hevy/__init__.py
@@ -21,6 +21,7 @@ HevyConfigEntry = ConfigEntry
 PLATFORMS: list[Platform] = [
     Platform.SENSOR,
     Platform.BINARY_SENSOR,
+    Platform.CALENDAR,
 ]
 
 

--- a/custom_components/hevy/calendar.py
+++ b/custom_components/hevy/calendar.py
@@ -1,0 +1,101 @@
+"""Calendar platform for hevy."""
+
+from __future__ import annotations
+
+from datetime import timedelta
+from typing import TYPE_CHECKING, Any
+
+from homeassistant.components.calendar import CalendarEntity, CalendarEvent
+
+from .entity import HevyEntity
+
+if TYPE_CHECKING:
+    from datetime import datetime
+
+    from homeassistant.core import HomeAssistant
+    from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+    from .coordinator import HevyDataUpdateCoordinator
+    from .data import HevyConfigEntry
+
+
+_DEFAULT_DURATION = timedelta(hours=1)
+
+
+def _workout_event(workout: dict[str, Any]) -> CalendarEvent | None:
+    """Build a CalendarEvent from a processed workout record."""
+    start = workout.get("start_time")
+    if start is None:
+        return None
+    duration_s = workout.get("duration_seconds") or 0
+    end = (
+        start + timedelta(seconds=duration_s)
+        if duration_s > 0
+        else start + _DEFAULT_DURATION
+    )
+    description_parts: list[str] = []
+    exercise_count = workout.get("exercise_count", 0)
+    if exercise_count:
+        description_parts.append(f"{exercise_count} exercises")
+    total_reps = workout.get("total_reps", 0)
+    if total_reps:
+        description_parts.append(f"{total_reps} reps")
+    volume_kg = workout.get("volume_kg") or 0
+    if volume_kg:
+        description_parts.append(f"{round(volume_kg, 1)} kg total")
+    return CalendarEvent(
+        start=start,
+        end=end,
+        summary=workout.get("title") or "Workout",
+        description=" • ".join(description_parts) or None,
+        uid=workout.get("id"),
+    )
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,  # noqa: ARG001
+    entry: HevyConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up the calendar platform."""
+    coordinator = entry.runtime_data.coordinator
+    async_add_entities([HevyCalendar(coordinator)])
+
+
+class HevyCalendar(HevyEntity, CalendarEntity):
+    """Calendar exposing recent workouts as events."""
+
+    _attr_translation_key = "workouts"
+    _attr_icon = "mdi:calendar-check"
+
+    def __init__(self, coordinator: HevyDataUpdateCoordinator) -> None:
+        """Initialize the calendar entity."""
+        super().__init__(coordinator)
+        self._attr_unique_id = f"{coordinator.config_entry.entry_id}_workouts_calendar"
+
+    @property
+    def event(self) -> CalendarEvent | None:
+        """Return the most recent workout as the 'current' event."""
+        last = (self.coordinator.data or {}).get("last_workout")
+        if not last:
+            return None
+        return _workout_event(last)
+
+    async def async_get_events(
+        self,
+        hass: HomeAssistant,  # noqa: ARG002
+        start_date: datetime,
+        end_date: datetime,
+    ) -> list[CalendarEvent]:
+        """Return workouts whose start_time falls in [start_date, end_date)."""
+        workouts = (self.coordinator.data or {}).get("workouts", {})
+        events: list[CalendarEvent] = []
+        for workout in workouts.values():
+            start = workout.get("start_time")
+            if start is None or start < start_date or start >= end_date:
+                continue
+            event = _workout_event(workout)
+            if event is not None:
+                events.append(event)
+        events.sort(key=lambda e: e.start)
+        return events

--- a/custom_components/hevy/manifest.json
+++ b/custom_components/hevy/manifest.json
@@ -8,5 +8,5 @@
   "documentation": "https://github.com/hudsonbrendon/HA-hevy",
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/hudsonbrendon/HA-hevy/issues",
-  "version": "0.3.0"
+  "version": "0.4.0"
 }

--- a/custom_components/hevy/translations/en.json
+++ b/custom_components/hevy/translations/en.json
@@ -55,6 +55,9 @@
                 "name": "Workout This Week",
                 "state": {"on": "Yes", "off": "No"}
             }
+        },
+        "calendar": {
+            "workouts": {"name": "Workouts"}
         }
     }
 }

--- a/custom_components/hevy/translations/pt-BR.json
+++ b/custom_components/hevy/translations/pt-BR.json
@@ -55,6 +55,9 @@
                 "name": "Treinou Esta Semana",
                 "state": {"on": "Sim", "off": "Não"}
             }
+        },
+        "calendar": {
+            "workouts": {"name": "Treinos"}
         }
     }
 }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -113,6 +113,20 @@ class _StubBinarySensorEntity:
     pass
 
 
+class _StubCalendarEntity:
+    pass
+
+
+@dataclass
+class _StubCalendarEvent:
+    start: Any
+    end: Any
+    summary: str
+    description: str | None = None
+    uid: str | None = None
+    location: str | None = None
+
+
 def _device_info(**kwargs: Any) -> dict[str, Any]:
     """Stand-in for homeassistant.helpers.device_registry.DeviceInfo."""
     return dict(kwargs)
@@ -160,7 +174,11 @@ def _install_ha_stubs() -> None:
     _mod("homeassistant.config_entries", ConfigEntry=object)
     _mod(
         "homeassistant.const",
-        Platform=types.SimpleNamespace(SENSOR="sensor", BINARY_SENSOR="binary_sensor"),
+        Platform=types.SimpleNamespace(
+            SENSOR="sensor",
+            BINARY_SENSOR="binary_sensor",
+            CALENDAR="calendar",
+        ),
         PERCENTAGE="%",
         UnitOfMass=_StubUnitOfMass,
         UnitOfTime=_StubUnitOfTime,
@@ -183,6 +201,11 @@ def _install_ha_stubs() -> None:
         BinarySensorEntity=_StubBinarySensorEntity,
         BinarySensorEntityDescription=_StubBaseDescription,
         BinarySensorDeviceClass=_StubBinarySensorDeviceClass,
+    )
+    _mod(
+        "homeassistant.components.calendar",
+        CalendarEntity=_StubCalendarEntity,
+        CalendarEvent=_StubCalendarEvent,
     )
 
 
@@ -216,6 +239,7 @@ def _register_hevy_package() -> None:
         "entity",
         "sensor",
         "binary_sensor",
+        "calendar",
     ):
         spec = importlib.util.spec_from_file_location(
             f"custom_components.hevy.{submodule}",

--- a/tests/test_calendar.py
+++ b/tests/test_calendar.py
@@ -1,0 +1,157 @@
+"""Tests for HevyCalendar entity + _workout_event helper."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+import pytest
+
+from custom_components.hevy.calendar import HevyCalendar, _workout_event
+
+
+def _workout(
+    workout_id: str,
+    title: str,
+    start: datetime,
+    duration_s: float = 3600,
+    *,
+    volume_kg: float = 1000.0,
+    total_reps: int = 30,
+    exercise_count: int = 3,
+) -> dict[str, Any]:
+    return {
+        "id": workout_id,
+        "title": title,
+        "start_time": start,
+        "duration_seconds": duration_s,
+        "volume_kg": volume_kg,
+        "total_reps": total_reps,
+        "exercise_count": exercise_count,
+    }
+
+
+class TestWorkoutEvent:
+    def test_full_record_maps_fields(self) -> None:
+        start = datetime(2026, 5, 17, 9, 0, tzinfo=UTC)
+        event = _workout_event(_workout("w1", "Push Day", start, 5400))
+        assert event.start == start
+        assert event.end == start + timedelta(seconds=5400)
+        assert event.summary == "Push Day"
+        assert event.uid == "w1"
+        assert "3 exercises" in event.description
+        assert "30 reps" in event.description
+        assert "1000.0 kg" in event.description
+
+    def test_zero_duration_falls_back_to_one_hour(self) -> None:
+        start = datetime(2026, 5, 17, 9, 0, tzinfo=UTC)
+        event = _workout_event(_workout("w1", "Push", start, 0))
+        assert event.end == start + timedelta(hours=1)
+
+    def test_missing_start_returns_none(self) -> None:
+        assert _workout_event({"id": "w1", "title": "X"}) is None
+
+    def test_missing_title_uses_workout_fallback(self) -> None:
+        start = datetime(2026, 5, 17, tzinfo=UTC)
+        event = _workout_event({"id": "w1", "start_time": start})
+        assert event.summary == "Workout"
+
+    def test_empty_optional_fields_omit_description(self) -> None:
+        start = datetime(2026, 5, 17, tzinfo=UTC)
+        event = _workout_event(
+            {
+                "id": "w1",
+                "title": "Cardio",
+                "start_time": start,
+                "duration_seconds": 600,
+                "volume_kg": 0,
+                "total_reps": 0,
+                "exercise_count": 0,
+            }
+        )
+        assert event.description is None
+
+
+@pytest.fixture
+def calendar(entity_coordinator: Any) -> Any:
+    return HevyCalendar(entity_coordinator)
+
+
+class TestHevyCalendarEntity:
+    def test_event_property_uses_last_workout(self, calendar: Any) -> None:
+        start = datetime(2026, 5, 17, 9, 0, tzinfo=UTC)
+        calendar.coordinator.data = {
+            "last_workout": _workout("w1", "Push Day", start),
+        }
+        event = calendar.event
+        assert event is not None
+        assert event.summary == "Push Day"
+        assert event.uid == "w1"
+
+    def test_event_none_when_no_last_workout(self, calendar: Any) -> None:
+        calendar.coordinator.data = {}
+        assert calendar.event is None
+
+    def test_event_none_when_data_is_none(self, calendar: Any) -> None:
+        calendar.coordinator.data = None
+        assert calendar.event is None
+
+    def test_unique_id_includes_entry_id(self, calendar: Any) -> None:
+        assert calendar._attr_unique_id == "entry-123_workouts_calendar"
+
+    @pytest.mark.asyncio
+    async def test_async_get_events_filters_by_window(self, calendar: Any) -> None:
+        w1_start = datetime(2026, 5, 17, 9, 0, tzinfo=UTC)
+        w2_start = datetime(2026, 5, 10, 9, 0, tzinfo=UTC)
+        w3_start = datetime(2026, 4, 1, 9, 0, tzinfo=UTC)
+        calendar.coordinator.data = {
+            "workouts": {
+                "w1": _workout("w1", "Push", w1_start),
+                "w2": _workout("w2", "Pull", w2_start),
+                "w3": _workout("w3", "Old", w3_start),
+            }
+        }
+        # Window covering May only
+        events = await calendar.async_get_events(
+            None,
+            datetime(2026, 5, 1, tzinfo=UTC),
+            datetime(2026, 6, 1, tzinfo=UTC),
+        )
+        uids = [e.uid for e in events]
+        assert uids == ["w2", "w1"]  # sorted by start ascending
+
+    @pytest.mark.asyncio
+    async def test_async_get_events_empty_when_no_workouts(self, calendar: Any) -> None:
+        calendar.coordinator.data = {"workouts": {}}
+        events = await calendar.async_get_events(
+            None,
+            datetime(2026, 5, 1, tzinfo=UTC),
+            datetime(2026, 6, 1, tzinfo=UTC),
+        )
+        assert events == []
+
+    @pytest.mark.asyncio
+    async def test_async_get_events_excludes_end_boundary(self, calendar: Any) -> None:
+        # start_date inclusive, end_date exclusive
+        boundary = datetime(2026, 5, 17, 9, 0, tzinfo=UTC)
+        calendar.coordinator.data = {
+            "workouts": {
+                "in": _workout(
+                    "in",
+                    "Inside",
+                    boundary,
+                ),
+                "edge": _workout(
+                    "edge",
+                    "On end boundary",
+                    boundary + timedelta(hours=1),
+                ),
+            }
+        }
+        events = await calendar.async_get_events(
+            None,
+            boundary,
+            boundary + timedelta(hours=1),
+        )
+        uids = [e.uid for e in events]
+        assert uids == ["in"]


### PR DESCRIPTION
Closes #71.

## What
New `calendar.py` exposing recent workouts as `CalendarEvent` so users can:
- Drop a workout calendar card into Lovelace with zero config.
- Trigger date-based automations via `calendar.get_events`.

## Mapping
| CalendarEvent field | Source |
|---|---|
| `start` | `workout.start_time` |
| `end` | `start + duration_seconds` (fallback `+1h` when duration is missing) |
| `summary` | `workout.title` (fallback `"Workout"`) |
| `description` | `"N exercises • M reps • V kg total"` (omits empty parts) |
| `uid` | `workout.id` |

## Internals
- `_workout_event(workout)` is a pure helper, fully unit-tested.
- `HevyCalendar.event` returns the most recent workout.
- `HevyCalendar.async_get_events` filters cached workouts by `[start, end)` window, sorted by start ascending.
- `Platform.CALENDAR` added to `PLATFORMS` in `__init__.py`.
- en + pt-BR translations for the calendar entity name.

## Tests
12 new (135 total passing) covering:
- Helper edge cases: missing start, missing title, zero duration, empty optional fields.
- Entity behaviour: `event` property, window filtering, end-boundary exclusivity, empty workouts dict, `data=None`.

## Manifest
Bumped `0.3.0 → 0.4.0`.

## Test plan
- [x] `pytest tests/` 135/135 passing
- [x] `ruff check .` passes
- [x] `ruff format . --check` passes
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)