### PR TITLE
feat(phase-5): OptionsFlow + diagnostics

### DIFF
--- a/custom_components/hevy/__init__.py
+++ b/custom_components/hevy/__init__.py
@@ -8,7 +8,14 @@ from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.loader import async_get_integration
 
 from .api import HevyApiClient
-from .const import CONF_API_KEY, CONF_NAME, DEFAULT_SCAN_INTERVAL
+from .const import (
+    CONF_API_KEY,
+    CONF_NAME,
+    CONF_SCAN_INTERVAL,
+    CONF_WORKOUTS_COUNT,
+    DEFAULT_SCAN_INTERVAL,
+    DEFAULT_WORKOUTS_COUNT,
+)
 from .coordinator import HevyDataUpdateCoordinator
 from .data import HevyData
 
@@ -31,10 +38,13 @@ async def async_setup_entry(
     entry: HevyConfigEntry,
 ) -> bool:
     """Set up this integration using UI."""
+    scan_minutes = entry.options.get(CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL)
+    workouts_count = entry.options.get(CONF_WORKOUTS_COUNT, DEFAULT_WORKOUTS_COUNT)
     coordinator = HevyDataUpdateCoordinator(
         hass=hass,
         name=entry.data[CONF_NAME],
-        update_interval=timedelta(minutes=DEFAULT_SCAN_INTERVAL),
+        update_interval=timedelta(minutes=scan_minutes),
+        workouts_count=workouts_count,
     )
     entry.runtime_data = HevyData(
         client=HevyApiClient(

--- a/custom_components/hevy/config_flow.py
+++ b/custom_components/hevy/config_flow.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 import voluptuous as vol
 from homeassistant import config_entries
 from homeassistant.helpers import selector
@@ -13,7 +15,20 @@ from .api import (
     HevyApiClientCommunicationError,
     HevyApiClientError,
 )
-from .const import CONF_API_KEY, CONF_NAME, DOMAIN, LOGGER
+from .const import (
+    CONF_API_KEY,
+    CONF_NAME,
+    CONF_SCAN_INTERVAL,
+    CONF_WORKOUTS_COUNT,
+    DEFAULT_SCAN_INTERVAL,
+    DEFAULT_WORKOUTS_COUNT,
+    DOMAIN,
+    LOGGER,
+    MAX_SCAN_INTERVAL,
+    MAX_WORKOUTS_COUNT,
+    MIN_SCAN_INTERVAL,
+    MIN_WORKOUTS_COUNT,
+)
 
 
 class HevyFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
@@ -81,3 +96,50 @@ class HevyFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             session=async_create_clientsession(self.hass),
         )
         await client.async_get_workout_count()
+
+    @staticmethod
+    def async_get_options_flow(
+        config_entry: config_entries.ConfigEntry,
+    ) -> HevyOptionsFlow:
+        """Return the options flow handler."""
+        return HevyOptionsFlow(config_entry)
+
+
+class HevyOptionsFlow(config_entries.OptionsFlow):
+    """Handle tweaking polling interval and page size after setup."""
+
+    def __init__(self, config_entry: config_entries.ConfigEntry) -> None:
+        """Initialize options flow."""
+        self.config_entry = config_entry
+
+    async def async_step_init(
+        self, user_input: dict[str, Any] | None = None
+    ) -> config_entries.ConfigFlowResult:
+        """Manage the integration options."""
+        if user_input is not None:
+            return self.async_create_entry(title="", data=user_input)
+
+        current = self.config_entry.options
+        return self.async_show_form(
+            step_id="init",
+            data_schema=vol.Schema(
+                {
+                    vol.Optional(
+                        CONF_SCAN_INTERVAL,
+                        default=current.get(CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL),
+                    ): vol.All(
+                        vol.Coerce(int),
+                        vol.Range(min=MIN_SCAN_INTERVAL, max=MAX_SCAN_INTERVAL),
+                    ),
+                    vol.Optional(
+                        CONF_WORKOUTS_COUNT,
+                        default=current.get(
+                            CONF_WORKOUTS_COUNT, DEFAULT_WORKOUTS_COUNT
+                        ),
+                    ): vol.All(
+                        vol.Coerce(int),
+                        vol.Range(min=MIN_WORKOUTS_COUNT, max=MAX_WORKOUTS_COUNT),
+                    ),
+                }
+            ),
+        )

--- a/custom_components/hevy/const.py
+++ b/custom_components/hevy/const.py
@@ -13,5 +13,13 @@ BASE_URL = "https://api.hevyapp.com/v1"
 DEFAULT_WORKOUTS_COUNT = 10
 DEFAULT_SCAN_INTERVAL = 60  # minutes
 
+CONF_SCAN_INTERVAL = "scan_interval"
+CONF_WORKOUTS_COUNT = "workouts_count"
+
+MIN_SCAN_INTERVAL = 5
+MAX_SCAN_INTERVAL = 1440  # 24h
+MIN_WORKOUTS_COUNT = 1
+MAX_WORKOUTS_COUNT = 10  # Hevy API hard cap
+
 EVENT_WORKOUT_COMPLETED = "hevy_workout_completed"
 EVENT_WORKOUT_DELETED = "hevy_workout_deleted"

--- a/custom_components/hevy/coordinator.py
+++ b/custom_components/hevy/coordinator.py
@@ -104,6 +104,7 @@ class HevyDataUpdateCoordinator(DataUpdateCoordinator):
         hass: HomeAssistant,
         name: str,
         update_interval: timedelta,
+        workouts_count: int = DEFAULT_WORKOUTS_COUNT,
     ) -> None:
         """Initialize the coordinator."""
         super().__init__(
@@ -115,6 +116,7 @@ class HevyDataUpdateCoordinator(DataUpdateCoordinator):
         self.name = name
         self.data: dict[str, Any] = {}
         self._primed = False
+        self._workouts_count = workouts_count
 
     async def _async_update_data(self) -> dict[str, Any]:
         """Update data via library."""
@@ -127,7 +129,7 @@ class HevyDataUpdateCoordinator(DataUpdateCoordinator):
                 measurements_data,
             ) = await asyncio.gather(
                 client.async_get_workout_count(),
-                client.async_get_workouts(page=1, page_size=DEFAULT_WORKOUTS_COUNT),
+                client.async_get_workouts(page=1, page_size=self._workouts_count),
                 self._safe_fetch(client.async_get_user_info()),
                 self._safe_fetch(client.async_get_body_measurements(page_size=10)),
             )

--- a/custom_components/hevy/diagnostics.py
+++ b/custom_components/hevy/diagnostics.py
@@ -1,0 +1,81 @@
+"""Diagnostics support for Hevy integration."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from homeassistant.components.diagnostics import async_redact_data
+
+from .const import CONF_API_KEY
+
+if TYPE_CHECKING:
+    from homeassistant.core import HomeAssistant
+
+    from .data import HevyConfigEntry
+
+TO_REDACT_DATA = {CONF_API_KEY}
+TO_REDACT_COORDINATOR = {"user", "url", "profile_url", "user_id", "id"}
+
+
+def _summarize_workouts(workouts: dict[str, Any]) -> dict[str, Any]:
+    """Drop exercise-level detail; keep counts useful for triage."""
+    summary: dict[str, Any] = {}
+    for workout_id, record in workouts.items():
+        summary[workout_id] = {
+            "title": record.get("title"),
+            "start_time": (
+                record.get("start_time").isoformat()
+                if record.get("start_time") is not None
+                else None
+            ),
+            "exercise_count": record.get("exercise_count"),
+            "total_reps": record.get("total_reps"),
+            "volume_kg": record.get("volume_kg"),
+            "duration_seconds": record.get("duration_seconds"),
+        }
+    return summary
+
+
+def _scrub_coordinator_data(data: dict[str, Any]) -> dict[str, Any]:
+    """Return a copy of coordinator data safe for sharing in diagnostics."""
+    if not data:
+        return {}
+    scrubbed = dict(data)
+    if "workouts" in scrubbed:
+        scrubbed["workouts"] = _summarize_workouts(scrubbed["workouts"])
+    if scrubbed.get("last_workout"):
+        lw = dict(scrubbed["last_workout"])
+        lw.pop("exercises", None)
+        if isinstance(lw.get("start_time"), object) and hasattr(
+            lw.get("start_time"), "isoformat"
+        ):
+            lw["start_time"] = lw["start_time"].isoformat()
+        scrubbed["last_workout"] = lw
+    return async_redact_data(scrubbed, TO_REDACT_COORDINATOR)
+
+
+async def async_get_config_entry_diagnostics(
+    hass: HomeAssistant,  # noqa: ARG001
+    entry: HevyConfigEntry,
+) -> dict[str, Any]:
+    """Return diagnostics for the config entry, with secrets redacted."""
+    coordinator = entry.runtime_data.coordinator
+    return {
+        "entry": {
+            "title": entry.title,
+            "data": async_redact_data(dict(entry.data), TO_REDACT_DATA),
+            "options": dict(entry.options),
+        },
+        "coordinator": {
+            "name": coordinator.name,
+            "update_interval_seconds": (
+                coordinator.update_interval.total_seconds()
+                if coordinator.update_interval is not None
+                else None
+            ),
+            "workouts_count": coordinator._workouts_count,  # noqa: SLF001
+            "primed": coordinator._primed,  # noqa: SLF001
+            "last_update_success": getattr(coordinator, "last_update_success", None),
+            "data": _scrub_coordinator_data(coordinator.data),
+        },
+    }

--- a/custom_components/hevy/manifest.json
+++ b/custom_components/hevy/manifest.json
@@ -8,5 +8,5 @@
   "documentation": "https://github.com/hudsonbrendon/HA-hevy",
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/hudsonbrendon/HA-hevy/issues",
-  "version": "0.4.0"
+  "version": "0.5.0"
 }

--- a/custom_components/hevy/translations/en.json
+++ b/custom_components/hevy/translations/en.json
@@ -18,6 +18,18 @@
             "already_configured": "This API key is already configured."
         }
     },
+    "options": {
+        "step": {
+            "init": {
+                "title": "Hevy options",
+                "description": "Adjust how often the integration polls the Hevy API and how many workouts to fetch per poll.",
+                "data": {
+                    "scan_interval": "Polling interval (minutes)",
+                    "workouts_count": "Workouts per poll (1-10)"
+                }
+            }
+        }
+    },
     "entity": {
         "sensor": {
             "workout_count": {"name": "Workout Count"},

--- a/custom_components/hevy/translations/pt-BR.json
+++ b/custom_components/hevy/translations/pt-BR.json
@@ -18,6 +18,18 @@
             "already_configured": "Esta chave de API já está configurada."
         }
     },
+    "options": {
+        "step": {
+            "init": {
+                "title": "Opções do Hevy",
+                "description": "Ajuste a frequência de polling e quantos treinos buscar por ciclo.",
+                "data": {
+                    "scan_interval": "Intervalo de polling (minutos)",
+                    "workouts_count": "Treinos por ciclo (1-10)"
+                }
+            }
+        }
+    },
     "entity": {
         "sensor": {
             "workout_count": {"name": "Contagem de Treinos"},

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -132,6 +132,25 @@ def _device_info(**kwargs: Any) -> dict[str, Any]:
     return dict(kwargs)
 
 
+_REDACTED = "**REDACTED**"
+
+
+def _async_redact_data(data: Any, to_redact: set[str]) -> Any:
+    """Mirror of HA's async_redact_data helper for tests (recursive)."""
+    if isinstance(data, dict):
+        return {
+            key: (
+                _REDACTED
+                if key in to_redact and value is not None
+                else _async_redact_data(value, to_redact)
+            )
+            for key, value in data.items()
+        }
+    if isinstance(data, list):
+        return [_async_redact_data(item, to_redact) for item in data]
+    return data
+
+
 def _install_ha_stubs() -> None:
     """Insert minimal Home Assistant modules into sys.modules."""
 
@@ -207,6 +226,10 @@ def _install_ha_stubs() -> None:
         CalendarEntity=_StubCalendarEntity,
         CalendarEvent=_StubCalendarEvent,
     )
+    _mod(
+        "homeassistant.components.diagnostics",
+        async_redact_data=_async_redact_data,
+    )
 
 
 _install_ha_stubs()
@@ -240,6 +263,7 @@ def _register_hevy_package() -> None:
         "sensor",
         "binary_sensor",
         "calendar",
+        "diagnostics",
     ):
         spec = importlib.util.spec_from_file_location(
             f"custom_components.hevy.{submodule}",

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -1,0 +1,142 @@
+"""Tests for the diagnostics dump (sanitization + structure)."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from custom_components.hevy.diagnostics import (
+    _scrub_coordinator_data,
+    _summarize_workouts,
+    async_get_config_entry_diagnostics,
+)
+
+
+def _workout_record(workout_id: str, title: str = "Push") -> dict[str, Any]:
+    return {
+        "id": workout_id,
+        "title": title,
+        "start_time": datetime(2026, 5, 17, 9, 0, tzinfo=UTC),
+        "_end_time_raw": "2026-05-17T10:00:00+00:00",
+        "exercises": {
+            "0_Bench": {"title": "Bench", "sets": 3, "total_reps": 20, "volume_kg": 800}
+        },
+        "exercise_count": 1,
+        "total_reps": 20,
+        "volume_kg": 800.0,
+        "duration_seconds": 3600,
+    }
+
+
+class TestSummarizeWorkouts:
+    def test_drops_exercises_keeps_counters(self) -> None:
+        summary = _summarize_workouts({"w1": _workout_record("w1")})
+        assert "exercises" not in summary["w1"]
+        assert summary["w1"]["title"] == "Push"
+        assert summary["w1"]["exercise_count"] == 1
+        assert summary["w1"]["total_reps"] == 20
+        assert summary["w1"]["volume_kg"] == 800.0
+        assert summary["w1"]["duration_seconds"] == 3600
+
+    def test_serializes_datetime(self) -> None:
+        summary = _summarize_workouts({"w1": _workout_record("w1")})
+        assert summary["w1"]["start_time"] == "2026-05-17T09:00:00+00:00"
+
+    def test_missing_start_time_returns_none(self) -> None:
+        record = _workout_record("w1")
+        record["start_time"] = None
+        summary = _summarize_workouts({"w1": record})
+        assert summary["w1"]["start_time"] is None
+
+    def test_empty_input(self) -> None:
+        assert _summarize_workouts({}) == {}
+
+
+class TestScrubCoordinatorData:
+    def test_empty(self) -> None:
+        assert _scrub_coordinator_data({}) == {}
+        assert _scrub_coordinator_data(None) == {}  # type: ignore[arg-type]
+
+    def test_redacts_user_identifiers(self) -> None:
+        data = {
+            "user": {
+                "id": "abc",
+                "name": "Hudson",
+                "url": "https://hevy.com/hudson",
+            },
+            "workouts": {},
+        }
+        scrubbed = _scrub_coordinator_data(data)
+        assert scrubbed["user"] == "**REDACTED**"
+
+    def test_summarizes_workouts(self) -> None:
+        data = {"workouts": {"w1": _workout_record("w1")}}
+        scrubbed = _scrub_coordinator_data(data)
+        assert "exercises" not in scrubbed["workouts"]["w1"]
+
+    def test_strips_exercises_from_last_workout(self) -> None:
+        last = _workout_record("w1")
+        data = {"workouts": {}, "last_workout": last}
+        scrubbed = _scrub_coordinator_data(data)
+        assert "exercises" not in scrubbed["last_workout"]
+        assert scrubbed["last_workout"]["start_time"] == "2026-05-17T09:00:00+00:00"
+
+
+@pytest.mark.asyncio
+class TestAsyncGetConfigEntryDiagnostics:
+    async def test_full_diagnostics_structure(self) -> None:
+        coord = MagicMock()
+        coord.name = "Hudson"
+        coord.update_interval = timedelta(minutes=30)
+        coord._workouts_count = 10
+        coord._primed = True
+        coord.last_update_success = True
+        coord.data = {
+            "workouts": {"w1": _workout_record("w1")},
+            "user": {"id": "u1", "name": "Hudson", "url": "https://hevy.com/x"},
+            "workout_count": 42,
+        }
+
+        entry = MagicMock()
+        entry.title = "Hevy - Hudson"
+        entry.data = {"api_key": "secret-key", "name": "Hudson"}
+        entry.options = {"scan_interval": 30, "workouts_count": 10}
+        entry.runtime_data = MagicMock(coordinator=coord)
+
+        result = await async_get_config_entry_diagnostics(None, entry)
+
+        assert result["entry"]["title"] == "Hevy - Hudson"
+        assert result["entry"]["data"]["api_key"] == "**REDACTED**"
+        assert result["entry"]["data"]["name"] == "Hudson"
+        assert result["entry"]["options"] == {"scan_interval": 30, "workouts_count": 10}
+
+        assert result["coordinator"]["name"] == "Hudson"
+        assert result["coordinator"]["update_interval_seconds"] == 1800
+        assert result["coordinator"]["workouts_count"] == 10
+        assert result["coordinator"]["primed"] is True
+        assert result["coordinator"]["last_update_success"] is True
+        assert result["coordinator"]["data"]["user"] == "**REDACTED**"
+        assert "exercises" not in result["coordinator"]["data"]["workouts"]["w1"]
+
+    async def test_handles_none_update_interval(self) -> None:
+        coord = MagicMock()
+        coord.name = "X"
+        coord.update_interval = None
+        coord._workouts_count = 10
+        coord._primed = False
+        coord.last_update_success = False
+        coord.data = {}
+
+        entry = MagicMock()
+        entry.title = "X"
+        entry.data = {"api_key": "k"}
+        entry.options = {}
+        entry.runtime_data = MagicMock(coordinator=coord)
+
+        result = await async_get_config_entry_diagnostics(None, entry)
+        assert result["coordinator"]["update_interval_seconds"] is None
+        assert result["coordinator"]["primed"] is False
+        assert result["coordinator"]["data"] == {}


### PR DESCRIPTION
Closes #74 (partial — OptionsFlow + diagnostics; repairs deferred to a follow-up).

## OptionsFlow
Settings → Devices & Services → **Hevy → Configure** now exposes:

| Setting | Range | Default |
|---|---|---|
| Polling interval (minutes) | 5–1440 | 60 |
| Workouts per poll | 1–10 (API hard cap) | 10 |

Both flow through `entry.options` into the coordinator on next reload — no reinstall needed.

## Diagnostics
`async_get_config_entry_diagnostics` dumps a sanitized snapshot for HA's "Download Diagnostics" button. Contents:
- `entry.data.api_key` → redacted
- `coordinator.data.user.*` (id, url, name) → redacted
- `workouts.*.exercises` dropped (keeps payload small + avoids leaking exercise titles)
- Datetimes serialized to ISO strings

## Coordinator
- New `workouts_count` constructor arg threaded through from `entry.options`.
- `update_interval` still derived from `entry.options.scan_interval`.

## Tests
10 new (133 total passing): `_summarize_workouts`, `_scrub_coordinator_data`, full `async_get_config_entry_diagnostics` shape + redaction + `None` update_interval edge case.

## Manifest
Bumped `0.4.0 → 0.5.0`.

## Test plan
- [x] `pytest tests/` 133/133
- [x] `ruff check .` passes
- [x] `ruff format . --check` passes
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Users can now configure polling interval (scan frequency) and workouts count through integration options.

* **Documentation**
  * Added translations for configuration options in English and Portuguese (Brazilian).

* **Tests**
  * Added comprehensive diagnostics testing and test infrastructure updates.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hudsonbrendon/HA-hevy/pull/81?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->