### PR TITLE
feat(phase-4): hevy.log_body_measurement & hevy.refresh services

### DIFF
--- a/custom_components/hevy/__init__.py
+++ b/custom_components/hevy/__init__.py
@@ -18,6 +18,7 @@ from .const import (
 )
 from .coordinator import HevyDataUpdateCoordinator
 from .data import HevyData
+from .services import async_register_services, async_unregister_services
 
 if TYPE_CHECKING:
     from .data import HevyConfigEntry
@@ -60,6 +61,7 @@ async def async_setup_entry(
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
     entry.async_on_unload(entry.add_update_listener(async_reload_entry))
+    async_register_services(hass)
 
     return True
 
@@ -69,7 +71,9 @@ async def async_unload_entry(
     entry: HevyConfigEntry,
 ) -> bool:
     """Handle removal of an entry."""
-    return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
+    unloaded = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
+    async_unregister_services(hass)
+    return unloaded
 
 
 async def async_reload_entry(

--- a/custom_components/hevy/api.py
+++ b/custom_components/hevy/api.py
@@ -27,13 +27,20 @@ class HevyApiClientAuthenticationError(
     """Exception to indicate an authentication error."""
 
 
+class HevyApiClientConflictError(
+    HevyApiClientError,
+):
+    """Exception to indicate the server reported a duplicate (HTTP 409)."""
+
+
 def _verify_response_or_raise(response: aiohttp.ClientResponse) -> None:
     """Verify that the response is valid."""
     if response.status in (401, 403):
         msg = "Invalid API key"
-        raise HevyApiClientAuthenticationError(
-            msg,
-        )
+        raise HevyApiClientAuthenticationError(msg)
+    if response.status == 409:
+        msg = "Resource already exists for the given key"
+        raise HevyApiClientConflictError(msg)
     response.raise_for_status()
 
 
@@ -85,6 +92,26 @@ class HevyApiClient:
             method="get",
             url=f"{BASE_URL}/body_measurements",
             params={"page": page, "pageSize": page_size},
+        )
+
+    async def async_create_body_measurement(
+        self, body: dict[str, Any]
+    ) -> dict[str, Any]:
+        """POST a new body measurement. Returns 409 if entry exists for date."""
+        return await self._api_wrapper(
+            method="post",
+            url=f"{BASE_URL}/body_measurements",
+            data=body,
+        )
+
+    async def async_update_body_measurement(
+        self, date: str, body: dict[str, Any]
+    ) -> dict[str, Any]:
+        """PUT (overwrite) body measurement for a given YYYY-MM-DD date."""
+        return await self._api_wrapper(
+            method="put",
+            url=f"{BASE_URL}/body_measurements/{date}",
+            data=body,
         )
 
     async def _api_wrapper(

--- a/custom_components/hevy/manifest.json
+++ b/custom_components/hevy/manifest.json
@@ -8,5 +8,5 @@
   "documentation": "https://github.com/hudsonbrendon/HA-hevy",
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/hudsonbrendon/HA-hevy/issues",
-  "version": "0.5.0"
+  "version": "0.6.0"
 }

--- a/custom_components/hevy/services.py
+++ b/custom_components/hevy/services.py
@@ -1,0 +1,158 @@
+"""Service handlers for the Hevy integration."""
+
+from __future__ import annotations
+
+from datetime import UTC, date, datetime
+from typing import TYPE_CHECKING, Any
+
+import voluptuous as vol
+from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
+from homeassistant.helpers import config_validation as cv
+
+from .api import HevyApiClientConflictError, HevyApiClientError
+from .const import DOMAIN, LOGGER
+
+if TYPE_CHECKING:
+    from homeassistant.core import HomeAssistant, ServiceCall
+
+SERVICE_LOG_BODY_MEASUREMENT = "log_body_measurement"
+SERVICE_REFRESH = "refresh"
+
+ATTR_ENTRY_ID = "entry_id"
+ATTR_DATE = "date"
+ATTR_WEIGHT_KG = "weight_kg"
+ATTR_FAT_PERCENT = "fat_percent"
+ATTR_LEAN_MASS_KG = "lean_mass_kg"
+
+_OPTIONAL_MEASUREMENT_FIELDS = (
+    ATTR_WEIGHT_KG,
+    ATTR_FAT_PERCENT,
+    ATTR_LEAN_MASS_KG,
+    "neck_cm",
+    "shoulder_cm",
+    "chest_cm",
+    "left_bicep_cm",
+    "right_bicep_cm",
+    "left_forearm_cm",
+    "right_forearm_cm",
+    "abdomen",
+    "waist",
+    "hips",
+    "left_thigh",
+    "right_thigh",
+    "left_calf",
+    "right_calf",
+)
+
+LOG_BODY_MEASUREMENT_SCHEMA = vol.Schema(
+    {
+        vol.Optional(ATTR_ENTRY_ID): cv.string,
+        vol.Optional(ATTR_DATE): cv.date,
+        **{
+            vol.Optional(field): vol.Coerce(float)
+            for field in _OPTIONAL_MEASUREMENT_FIELDS
+        },
+    }
+)
+
+REFRESH_SCHEMA = vol.Schema({vol.Optional(ATTR_ENTRY_ID): cv.string})
+
+
+def _resolve_entry(hass: HomeAssistant, entry_id: str | None) -> Any:
+    """Look up the Hevy config entry matching entry_id, or the only one."""
+    entries = hass.config_entries.async_entries(DOMAIN)
+    if not entries:
+        msg = "No Hevy integration is configured."
+        raise ServiceValidationError(msg)
+    if entry_id is not None:
+        for entry in entries:
+            if entry.entry_id == entry_id:
+                return entry
+        msg = f"No Hevy config entry with id {entry_id!r}."
+        raise ServiceValidationError(msg)
+    if len(entries) > 1:
+        msg = "Multiple Hevy integrations configured; pass 'entry_id' to target one."
+        raise ServiceValidationError(msg)
+    return entries[0]
+
+
+def _build_measurement_payload(
+    call_data: dict[str, Any],
+) -> tuple[str, dict[str, Any]]:
+    """Extract (date_str, body) from the service call data."""
+    raw_date = call_data.get(ATTR_DATE) or datetime.now(tz=UTC).date()
+    if isinstance(raw_date, date) and not isinstance(raw_date, datetime):
+        date_str = raw_date.isoformat()
+    elif isinstance(raw_date, datetime):
+        date_str = raw_date.date().isoformat()
+    else:
+        date_str = str(raw_date)
+    body = {
+        field: call_data[field]
+        for field in _OPTIONAL_MEASUREMENT_FIELDS
+        if field in call_data
+    }
+    if not body:
+        msg = "log_body_measurement requires at least one measurement field."
+        raise ServiceValidationError(msg)
+    body["date"] = date_str
+    return date_str, body
+
+
+async def _handle_log_body_measurement(hass: HomeAssistant, call: ServiceCall) -> None:
+    entry = _resolve_entry(hass, call.data.get(ATTR_ENTRY_ID))
+    date_str, body = _build_measurement_payload(call.data)
+    client = entry.runtime_data.client
+    try:
+        await client.async_create_body_measurement(body)
+    except HevyApiClientConflictError:
+        # Entry already exists for the date → overwrite via PUT.
+        put_body = {k: v for k, v in body.items() if k != "date"}
+        try:
+            await client.async_update_body_measurement(date_str, put_body)
+        except HevyApiClientError as err:
+            msg = f"Failed to update body measurement for {date_str}: {err}"
+            raise HomeAssistantError(msg) from err
+    except HevyApiClientError as err:
+        msg = f"Failed to log body measurement: {err}"
+        raise HomeAssistantError(msg) from err
+    await entry.runtime_data.coordinator.async_request_refresh()
+
+
+async def _handle_refresh(hass: HomeAssistant, call: ServiceCall) -> None:
+    entry = _resolve_entry(hass, call.data.get(ATTR_ENTRY_ID))
+    LOGGER.debug("Refreshing Hevy coordinator for entry %s", entry.entry_id)
+    await entry.runtime_data.coordinator.async_request_refresh()
+
+
+def async_register_services(hass: HomeAssistant) -> None:
+    """Register integration-level services if not already registered."""
+    if hass.services.has_service(DOMAIN, SERVICE_LOG_BODY_MEASUREMENT):
+        return
+
+    async def log_body(call: ServiceCall) -> None:
+        await _handle_log_body_measurement(hass, call)
+
+    async def refresh(call: ServiceCall) -> None:
+        await _handle_refresh(hass, call)
+
+    hass.services.async_register(
+        DOMAIN,
+        SERVICE_LOG_BODY_MEASUREMENT,
+        log_body,
+        schema=LOG_BODY_MEASUREMENT_SCHEMA,
+    )
+    hass.services.async_register(
+        DOMAIN,
+        SERVICE_REFRESH,
+        refresh,
+        schema=REFRESH_SCHEMA,
+    )
+
+
+def async_unregister_services(hass: HomeAssistant) -> None:
+    """Drop services when the last config entry is removed."""
+    if hass.config_entries.async_entries(DOMAIN):
+        return
+    hass.services.async_remove(DOMAIN, SERVICE_LOG_BODY_MEASUREMENT)
+    hass.services.async_remove(DOMAIN, SERVICE_REFRESH)

--- a/custom_components/hevy/services.yaml
+++ b/custom_components/hevy/services.yaml
@@ -1,0 +1,63 @@
+log_body_measurement:
+  name: Log body measurement
+  description: >
+    Record a body measurement on Hevy for the given date. If an entry already
+    exists for that date it is overwritten. At least one measurement field is
+    required.
+  fields:
+    entry_id:
+      name: Config entry
+      description: ID of the Hevy integration to target (omit if only one is configured).
+      example: "abc123def456"
+      required: false
+      selector:
+        text:
+    date:
+      name: Date
+      description: Date of the measurement (defaults to today, UTC).
+      required: false
+      example: "2026-05-17"
+      selector:
+        date:
+    weight_kg:
+      name: Weight (kg)
+      example: 82.5
+      required: false
+      selector:
+        number:
+          min: 1
+          max: 500
+          step: 0.1
+          unit_of_measurement: kg
+    fat_percent:
+      name: Body fat (%)
+      example: 18.5
+      required: false
+      selector:
+        number:
+          min: 0
+          max: 100
+          step: 0.1
+          unit_of_measurement: "%"
+    lean_mass_kg:
+      name: Lean mass (kg)
+      example: 65.0
+      required: false
+      selector:
+        number:
+          min: 1
+          max: 500
+          step: 0.1
+          unit_of_measurement: kg
+
+refresh:
+  name: Refresh
+  description: Force the Hevy coordinator to poll the API immediately.
+  fields:
+    entry_id:
+      name: Config entry
+      description: ID of the Hevy integration to target (omit if only one is configured).
+      required: false
+      example: "abc123def456"
+      selector:
+        text:

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,3 +1,4 @@
 -r requirements.txt
 pytest==8.3.4
 pytest-asyncio==0.25.2
+voluptuous==0.15.2

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 import sys
 import types
 from dataclasses import dataclass
-from datetime import UTC, datetime
+from datetime import UTC, date, datetime
 from pathlib import Path
 from typing import Any
 
@@ -53,6 +53,14 @@ class _StubUpdateFailed(Exception):
 
 class _StubConfigEntryAuthFailed(Exception):
     """Stub for ConfigEntryAuthFailed."""
+
+
+class _StubHomeAssistantError(Exception):
+    """Stub for HomeAssistantError."""
+
+
+class _StubServiceValidationError(_StubHomeAssistantError):
+    """Stub for ServiceValidationError."""
 
 
 class _StubEntityCategory:
@@ -132,6 +140,13 @@ def _device_info(**kwargs: Any) -> dict[str, Any]:
     return dict(kwargs)
 
 
+def _parse_date(value: Any) -> Any:
+    """Minimal cv.date stand-in (passes through date/datetime, parses str)."""
+    if isinstance(value, datetime | date):
+        return value
+    return datetime.strptime(str(value), "%Y-%m-%d").replace(tzinfo=UTC).date()
+
+
 _REDACTED = "**REDACTED**"
 
 
@@ -173,6 +188,8 @@ def _install_ha_stubs() -> None:
     _mod(
         "homeassistant.exceptions",
         ConfigEntryAuthFailed=_StubConfigEntryAuthFailed,
+        HomeAssistantError=_StubHomeAssistantError,
+        ServiceValidationError=_StubServiceValidationError,
     )
     _pkg("homeassistant.helpers")
     _mod(
@@ -188,6 +205,11 @@ def _install_ha_stubs() -> None:
     _mod(
         "homeassistant.helpers.entity",
         EntityCategory=_StubEntityCategory,
+    )
+    _mod(
+        "homeassistant.helpers.config_validation",
+        string=str,
+        date=_parse_date,
     )
     _mod("homeassistant.core", HomeAssistant=object)
     _mod("homeassistant.config_entries", ConfigEntry=object)
@@ -264,6 +286,7 @@ def _register_hevy_package() -> None:
         "binary_sensor",
         "calendar",
         "diagnostics",
+        "services",
     ):
         spec = importlib.util.spec_from_file_location(
             f"custom_components.hevy.{submodule}",

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -12,6 +12,7 @@ from custom_components.hevy.api import (
     HevyApiClient,
     HevyApiClientAuthenticationError,
     HevyApiClientCommunicationError,
+    HevyApiClientConflictError,
     HevyApiClientError,
 )
 
@@ -22,7 +23,7 @@ def _build_response(*, status: int = 200, json_payload: Any = None) -> MagicMock
     response.status = status
     response.json = AsyncMock(return_value=json_payload or {})
     response.raise_for_status = MagicMock()
-    if status >= 400 and status not in (401, 403):
+    if status >= 400 and status not in (401, 403, 409):
         response.raise_for_status.side_effect = aiohttp.ClientResponseError(
             request_info=MagicMock(),
             history=(),
@@ -101,6 +102,13 @@ class TestErrorHandling:
 
         with pytest.raises(HevyApiClientAuthenticationError):
             await client.async_get_workout_count()
+
+    async def test_409_raises_conflict_error(self) -> None:
+        response = _build_response(status=409)
+        session = _build_session(response)
+        client = HevyApiClient(api_key="key", session=session)
+        with pytest.raises(HevyApiClientConflictError):
+            await client.async_create_body_measurement({"date": "2026-05-17"})
 
     async def test_500_raises_communication_error(self) -> None:
         response = _build_response(status=500)

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -1,0 +1,192 @@
+"""Tests for service handlers (log_body_measurement, refresh)."""
+
+from __future__ import annotations
+
+from datetime import UTC, date, datetime
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
+
+from custom_components.hevy.api import (
+    HevyApiClientConflictError,
+    HevyApiClientError,
+)
+from custom_components.hevy.services import (
+    ATTR_DATE,
+    ATTR_ENTRY_ID,
+    ATTR_FAT_PERCENT,
+    ATTR_WEIGHT_KG,
+    _build_measurement_payload,
+    _handle_log_body_measurement,
+    _handle_refresh,
+    _resolve_entry,
+)
+
+
+def _make_hass(entries: list[Any]) -> Any:
+    hass = MagicMock()
+    hass.config_entries.async_entries = MagicMock(return_value=entries)
+    return hass
+
+
+def _make_entry(entry_id: str = "abc") -> Any:
+    entry = SimpleNamespace()
+    entry.entry_id = entry_id
+    client = MagicMock()
+    client.async_create_body_measurement = AsyncMock()
+    client.async_update_body_measurement = AsyncMock()
+    coordinator = MagicMock()
+    coordinator.async_request_refresh = AsyncMock()
+    entry.runtime_data = SimpleNamespace(client=client, coordinator=coordinator)
+    return entry
+
+
+class TestResolveEntry:
+    def test_no_entries_raises(self) -> None:
+        with pytest.raises(ServiceValidationError):
+            _resolve_entry(_make_hass([]), None)
+
+    def test_single_entry_returned_without_id(self) -> None:
+        entry = _make_entry("only")
+        assert _resolve_entry(_make_hass([entry]), None) is entry
+
+    def test_multiple_entries_require_id(self) -> None:
+        e1, e2 = _make_entry("a"), _make_entry("b")
+        with pytest.raises(ServiceValidationError):
+            _resolve_entry(_make_hass([e1, e2]), None)
+
+    def test_explicit_id_matches(self) -> None:
+        e1, e2 = _make_entry("a"), _make_entry("b")
+        assert _resolve_entry(_make_hass([e1, e2]), "b") is e2
+
+    def test_unknown_id_raises(self) -> None:
+        with pytest.raises(ServiceValidationError):
+            _resolve_entry(_make_hass([_make_entry("a")]), "missing")
+
+
+class TestBuildMeasurementPayload:
+    def test_uses_today_when_date_missing(self) -> None:
+        date_str, body = _build_measurement_payload({ATTR_WEIGHT_KG: 80})
+        today = datetime.now(tz=UTC).date().isoformat()
+        assert date_str == today
+        assert body == {"date": today, "weight_kg": 80}
+
+    def test_date_object(self) -> None:
+        d = date(2026, 5, 1)
+        date_str, body = _build_measurement_payload(
+            {ATTR_DATE: d, ATTR_WEIGHT_KG: 82.0}
+        )
+        assert date_str == "2026-05-01"
+        assert body["weight_kg"] == 82.0
+
+    def test_datetime_object(self) -> None:
+        dt = datetime(2026, 5, 1, 12, 0, tzinfo=UTC)
+        date_str, _ = _build_measurement_payload({ATTR_DATE: dt, ATTR_WEIGHT_KG: 80})
+        assert date_str == "2026-05-01"
+
+    def test_requires_at_least_one_field(self) -> None:
+        with pytest.raises(ServiceValidationError):
+            _build_measurement_payload({ATTR_DATE: date(2026, 5, 1)})
+
+    def test_multiple_fields(self) -> None:
+        _, body = _build_measurement_payload(
+            {
+                ATTR_DATE: date(2026, 5, 1),
+                ATTR_WEIGHT_KG: 80,
+                ATTR_FAT_PERCENT: 18.5,
+            }
+        )
+        assert body == {"date": "2026-05-01", "weight_kg": 80, "fat_percent": 18.5}
+
+
+@pytest.mark.asyncio
+class TestLogBodyMeasurement:
+    async def test_happy_path_posts(self) -> None:
+        entry = _make_entry()
+        hass = _make_hass([entry])
+        call = SimpleNamespace(data={ATTR_DATE: date(2026, 5, 1), ATTR_WEIGHT_KG: 80})
+
+        await _handle_log_body_measurement(hass, call)
+
+        entry.runtime_data.client.async_create_body_measurement.assert_awaited_once()
+        body = entry.runtime_data.client.async_create_body_measurement.await_args.args[
+            0
+        ]
+        assert body["date"] == "2026-05-01"
+        assert body["weight_kg"] == 80
+        entry.runtime_data.client.async_update_body_measurement.assert_not_called()
+        entry.runtime_data.coordinator.async_request_refresh.assert_awaited_once()
+
+    async def test_409_falls_back_to_put(self) -> None:
+        entry = _make_entry()
+        entry.runtime_data.client.async_create_body_measurement.side_effect = (
+            HevyApiClientConflictError("dup")
+        )
+        hass = _make_hass([entry])
+        call = SimpleNamespace(
+            data={ATTR_DATE: date(2026, 5, 1), ATTR_WEIGHT_KG: 80, ATTR_FAT_PERCENT: 18}
+        )
+
+        await _handle_log_body_measurement(hass, call)
+
+        entry.runtime_data.client.async_update_body_measurement.assert_awaited_once()
+        args = entry.runtime_data.client.async_update_body_measurement.await_args.args
+        assert args[0] == "2026-05-01"
+        assert "date" not in args[1]
+        assert args[1] == {"weight_kg": 80, "fat_percent": 18}
+        entry.runtime_data.coordinator.async_request_refresh.assert_awaited_once()
+
+    async def test_put_failure_wraps_as_homeassistant_error(self) -> None:
+        entry = _make_entry()
+        entry.runtime_data.client.async_create_body_measurement.side_effect = (
+            HevyApiClientConflictError("dup")
+        )
+        entry.runtime_data.client.async_update_body_measurement.side_effect = (
+            HevyApiClientError("network")
+        )
+        hass = _make_hass([entry])
+        call = SimpleNamespace(data={ATTR_DATE: date(2026, 5, 1), ATTR_WEIGHT_KG: 80})
+
+        with pytest.raises(HomeAssistantError):
+            await _handle_log_body_measurement(hass, call)
+
+    async def test_post_failure_wraps_as_homeassistant_error(self) -> None:
+        entry = _make_entry()
+        entry.runtime_data.client.async_create_body_measurement.side_effect = (
+            HevyApiClientError("boom")
+        )
+        hass = _make_hass([entry])
+        call = SimpleNamespace(data={ATTR_DATE: date(2026, 5, 1), ATTR_WEIGHT_KG: 80})
+
+        with pytest.raises(HomeAssistantError):
+            await _handle_log_body_measurement(hass, call)
+
+    async def test_validation_error_when_no_fields(self) -> None:
+        entry = _make_entry()
+        hass = _make_hass([entry])
+        call = SimpleNamespace(data={ATTR_DATE: date(2026, 5, 1)})
+        with pytest.raises(ServiceValidationError):
+            await _handle_log_body_measurement(hass, call)
+
+    async def test_targets_specific_entry_by_id(self) -> None:
+        e1 = _make_entry("a")
+        e2 = _make_entry("b")
+        hass = _make_hass([e1, e2])
+        call = SimpleNamespace(data={ATTR_ENTRY_ID: "b", ATTR_WEIGHT_KG: 80})
+
+        await _handle_log_body_measurement(hass, call)
+
+        e1.runtime_data.client.async_create_body_measurement.assert_not_called()
+        e2.runtime_data.client.async_create_body_measurement.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+class TestRefresh:
+    async def test_requests_refresh(self) -> None:
+        entry = _make_entry()
+        hass = _make_hass([entry])
+        await _handle_refresh(hass, SimpleNamespace(data={}))
+        entry.runtime_data.coordinator.async_request_refresh.assert_awaited_once()


### PR DESCRIPTION
Closes #73 (partial — body-measurement + refresh; `create_workout` deferred since it needs an exercise-template lookup helper).

## New services

### `hevy.log_body_measurement`
POSTs to `/v1/body_measurements`. Falls back to PUT on 409 (entry already exists for the date) so re-logging the same day overwrites instead of failing. Refreshes the coordinator on success.

Use case: wire your smart scale (Withings/Mi/Eufy) → automation → `hevy.log_body_measurement` → weight auto-syncs to Hevy.

```yaml
automation:
  - alias: Auto-sync scale to Hevy
    trigger:
      - platform: state
        entity_id: sensor.withings_weight
    action:
      - service: hevy.log_body_measurement
        data:
          weight_kg: "{{ states('sensor.withings_weight') | float }}"
          fat_percent: "{{ states('sensor.withings_fat_ratio') | float }}"
```

### `hevy.refresh`
Forces `coordinator.async_request_refresh()`. Useful right after logging a workout on the Hevy mobile app to sync HA immediately instead of waiting for the next poll.

Both services accept an optional `entry_id` when multiple Hevy integrations are configured; otherwise auto-target the only entry.

## API client
- `async_create_body_measurement(body)` — POST
- `async_update_body_measurement(date, body)` — PUT
- New `HevyApiClientConflictError` raised on HTTP 409 so services can detect and switch to PUT cleanly.

## Wiring
- Services registered in `async_setup_entry`, unregistered on last entry removal.
- `services.yaml` with number/date selectors for nice UI in Developer Tools → Services.

## Tests
17 new (**151 total passing**): entry resolution (no entries, single, multi, by id, unknown id), payload building (today default, date objects, datetime, no-fields validation), full POST → 409 → PUT flow with success and failure variants.

## Manifest
Bumped `0.5.0 → 0.6.0`.

## Test plan
- [x] `pytest tests/` 151/151
- [x] `ruff check .` passes
- [x] `ruff format . --check` passes
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)