### PR TITLE
feat(phase-3.1): /workouts/events polling + hevy_workout_updated event

### DIFF
--- a/custom_components/hevy/api.py
+++ b/custom_components/hevy/api.py
@@ -60,6 +60,19 @@ class HevyApiClient:
             "api-key": api_key,
         }
 
+    async def async_get_workout_events(
+        self,
+        since: str,
+        page: int = 1,
+        page_size: int = 10,
+    ) -> dict[str, Any]:
+        """Get workout events (updates + deletes) since ISO 8601 timestamp."""
+        return await self._api_wrapper(
+            method="get",
+            url=f"{BASE_URL}/workouts/events",
+            params={"since": since, "page": page, "pageSize": page_size},
+        )
+
     async def async_get_workout_count(self) -> dict[str, Any]:
         """Get workout count from the API."""
         return await self._api_wrapper(

--- a/custom_components/hevy/const.py
+++ b/custom_components/hevy/const.py
@@ -23,3 +23,4 @@ MAX_WORKOUTS_COUNT = 10  # Hevy API hard cap
 
 EVENT_WORKOUT_COMPLETED = "hevy_workout_completed"
 EVENT_WORKOUT_DELETED = "hevy_workout_deleted"
+EVENT_WORKOUT_UPDATED = "hevy_workout_updated"

--- a/custom_components/hevy/coordinator.py
+++ b/custom_components/hevy/coordinator.py
@@ -19,6 +19,7 @@ from .const import (
     DOMAIN,
     EVENT_WORKOUT_COMPLETED,
     EVENT_WORKOUT_DELETED,
+    EVENT_WORKOUT_UPDATED,
     LOGGER,
 )
 
@@ -117,6 +118,7 @@ class HevyDataUpdateCoordinator(DataUpdateCoordinator):
         self.data: dict[str, Any] = {}
         self._primed = False
         self._workouts_count = workouts_count
+        self._events_cursor: str | None = None
 
     async def _async_update_data(self) -> dict[str, Any]:
         """Update data via library."""
@@ -143,8 +145,36 @@ class HevyDataUpdateCoordinator(DataUpdateCoordinator):
             workout_count_data, workouts_data, user_data, measurements_data
         )
         self._fire_workout_events(previous_workouts, new_state["workouts"])
+        await self._poll_workout_updates(new_state["workouts"])
         self._primed = True
         return new_state
+
+    async def _poll_workout_updates(self, workouts: dict[str, dict[str, Any]]) -> None:
+        """Query the events endpoint and fire `hevy_workout_updated` for changes."""
+        if not self._primed:
+            # First refresh — seed cursor to "now" so the next poll only sees
+            # genuinely-new events instead of replaying the workout history.
+            self._events_cursor = datetime.now(tz=UTC).isoformat()
+            return
+        cursor = self._events_cursor or datetime.now(tz=UTC).isoformat()
+        try:
+            response = (
+                await self.config_entry.runtime_data.client.async_get_workout_events(  # noqa: E501
+                    since=cursor
+                )
+            )
+        except HevyApiClientError as err:
+            LOGGER.debug("Workout events poll failed: %s", err)
+            return
+        for event in response.get("events", []):
+            if event.get("type") != "updated":
+                continue
+            workout_id = (event.get("workout") or {}).get("id")
+            if workout_id and workout_id in workouts:
+                self.hass.bus.async_fire(
+                    EVENT_WORKOUT_UPDATED, _event_payload(workouts[workout_id])
+                )
+        self._events_cursor = datetime.now(tz=UTC).isoformat()
 
     def _fire_workout_events(
         self,
@@ -289,6 +319,7 @@ class HevyDataUpdateCoordinator(DataUpdateCoordinator):
             "title": workout["title"],
             "start_time": start_time,
             "_end_time_raw": workout.get("end_time"),
+            "updated_at": workout.get("updated_at"),
             "exercises": exercises_data,
             "volume_kg": volume_kg,
             "total_reps": total_reps,

--- a/custom_components/hevy/coordinator.py
+++ b/custom_components/hevy/coordinator.py
@@ -158,11 +158,8 @@ class HevyDataUpdateCoordinator(DataUpdateCoordinator):
             return
         cursor = self._events_cursor or datetime.now(tz=UTC).isoformat()
         try:
-            response = (
-                await self.config_entry.runtime_data.client.async_get_workout_events(  # noqa: E501
-                    since=cursor
-                )
-            )
+            client = self.config_entry.runtime_data.client
+            response = await client.async_get_workout_events(since=cursor)
         except HevyApiClientError as err:
             LOGGER.debug("Workout events poll failed: %s", err)
             return

--- a/custom_components/hevy/manifest.json
+++ b/custom_components/hevy/manifest.json
@@ -8,5 +8,5 @@
   "documentation": "https://github.com/hudsonbrendon/HA-hevy",
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/hudsonbrendon/HA-hevy/issues",
-  "version": "0.6.0"
+  "version": "0.7.0"
 }

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -84,6 +84,21 @@ class TestEndpointDispatch:
         assert kwargs["params"] == {"page": 3, "pageSize": 10}
         assert kwargs["url"].endswith("/body_measurements")
 
+    async def test_workout_events_endpoint_passes_since(self) -> None:
+        response = _build_response(json_payload={"events": [], "page": 1})
+        session = _build_session(response)
+        client = HevyApiClient(api_key="key", session=session)
+
+        await client.async_get_workout_events(since="2026-05-17T00:00:00Z")
+
+        kwargs = session.request.await_args.kwargs
+        assert kwargs["params"] == {
+            "since": "2026-05-17T00:00:00Z",
+            "page": 1,
+            "pageSize": 10,
+        }
+        assert kwargs["url"].endswith("/workouts/events")
+
 
 @pytest.mark.asyncio
 class TestErrorHandling:

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -3,14 +3,17 @@
 from __future__ import annotations
 
 from datetime import UTC, datetime
+from types import SimpleNamespace
 from typing import Any
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
+from custom_components.hevy.api import HevyApiClientError
 from custom_components.hevy.const import (
     EVENT_WORKOUT_COMPLETED,
     EVENT_WORKOUT_DELETED,
+    EVENT_WORKOUT_UPDATED,
 )
 from custom_components.hevy.coordinator import (
     HevyDataUpdateCoordinator,
@@ -135,3 +138,92 @@ class TestFireWorkoutEvents:
             for c in coord_with_bus.hass.bus.async_fire.call_args_list
         }
         assert titles == {"A", "B", "C"}
+
+
+@pytest.fixture
+def coord_with_events_client() -> Any:
+    """Coordinator wired with hass.bus and a stubbed events-endpoint client."""
+    coord = HevyDataUpdateCoordinator.__new__(HevyDataUpdateCoordinator)
+    coord.name = "Hudson"
+    coord.hass = MagicMock()
+    coord.hass.bus = MagicMock()
+    client = MagicMock()
+    client.async_get_workout_events = AsyncMock()
+    coord.config_entry = SimpleNamespace(runtime_data=SimpleNamespace(client=client))
+    coord._primed = True
+    coord._events_cursor = "2026-05-17T11:00:00+00:00"
+    return coord
+
+
+@pytest.mark.asyncio
+class TestPollWorkoutUpdates:
+    async def test_fires_updated_for_cached_workouts(
+        self, coord_with_events_client: Any
+    ) -> None:
+        coord = coord_with_events_client
+        coord.config_entry.runtime_data.client.async_get_workout_events.return_value = {
+            "events": [
+                {"type": "updated", "workout": {"id": "w1"}},
+                {"type": "updated", "workout": {"id": "unknown"}},
+                {"type": "deleted", "id": "w2"},
+            ]
+        }
+
+        await coord._poll_workout_updates({"w1": _record("w1"), "w3": _record("w3")})
+
+        # Only w1 fires (cached); 'unknown' workout skipped; deleted skipped.
+        coord.hass.bus.async_fire.assert_called_once()
+        event, payload = coord.hass.bus.async_fire.call_args.args
+        assert event == EVENT_WORKOUT_UPDATED
+        assert payload["id"] == "w1"
+
+    async def test_first_run_seeds_cursor_and_skips(self) -> None:
+        coord = HevyDataUpdateCoordinator.__new__(HevyDataUpdateCoordinator)
+        coord.hass = MagicMock()
+        coord.hass.bus = MagicMock()
+        client = MagicMock()
+        client.async_get_workout_events = AsyncMock()
+        coord.config_entry = SimpleNamespace(
+            runtime_data=SimpleNamespace(client=client)
+        )
+        coord._primed = False
+        coord._events_cursor = None
+
+        await coord._poll_workout_updates({"w1": _record("w1")})
+
+        client.async_get_workout_events.assert_not_called()
+        coord.hass.bus.async_fire.assert_not_called()
+        assert coord._events_cursor is not None
+
+    async def test_api_error_does_not_crash(
+        self, coord_with_events_client: Any
+    ) -> None:
+        coord = coord_with_events_client
+        coord.config_entry.runtime_data.client.async_get_workout_events.side_effect = (
+            HevyApiClientError("boom")
+        )
+
+        # Must not raise — events poll is best-effort.
+        await coord._poll_workout_updates({"w1": _record("w1")})
+        coord.hass.bus.async_fire.assert_not_called()
+
+    async def test_advances_cursor_after_successful_poll(
+        self, coord_with_events_client: Any
+    ) -> None:
+        coord = coord_with_events_client
+        before = coord._events_cursor
+        coord.config_entry.runtime_data.client.async_get_workout_events.return_value = {
+            "events": []
+        }
+        await coord._poll_workout_updates({})
+        assert coord._events_cursor != before
+
+    async def test_no_updated_events_no_fires(
+        self, coord_with_events_client: Any
+    ) -> None:
+        coord = coord_with_events_client
+        coord.config_entry.runtime_data.client.async_get_workout_events.return_value = {
+            "events": [{"type": "deleted", "id": "w1"}]
+        }
+        await coord._poll_workout_updates({"w1": _record("w1")})
+        coord.hass.bus.async_fire.assert_not_called()


### PR DESCRIPTION
Closes #72.

## What
After each successful main refresh, the coordinator now also polls `/v1/workouts/events?since=<cursor>` to detect **updates** to workouts already in the cache (e.g. user fixed a typo or corrected reps in the Hevy app) and fires a new `hevy_workout_updated` event for each.

## Why
Phase 3 (diff-based) caught new + deleted workouts but couldn't see edits. The events endpoint surfaces every change since the last cursor, so we now cover the full life cycle:

| Lifecycle | Detected by | Event |
|---|---|---|
| New workout | diff (cache delta) | `hevy_workout_completed` |
| Deleted | diff (cache delta) | `hevy_workout_deleted` |
| **Updated** | **events endpoint** | **`hevy_workout_updated`** (new) |

## Cursor handling
- First refresh seeds the cursor to "now" without polling — avoids replaying history on HA startup.
- Subsequent refreshes use the stored cursor; advance to "now" on success.
- Failures in the events endpoint log at DEBUG and don't block the main refresh (best-effort).

## API
- `async_get_workout_events(since, page, page_size)` — GET `/v1/workouts/events`.

## Coordinator
- New `_events_cursor` on the instance.
- New `_poll_workout_updates(workouts)` method invoked after `_fire_workout_events`.
- Workout records now carry `updated_at` (already exposed by `/v1/workouts`).

## Tests
6 new (**157 total passing**):
- Endpoint parameter passthrough.
- Updates fire only for workouts present in the cache.
- First-run cursor seeding without API call.
- API errors swallowed silently.
- Cursor advances on success.
- Deleted-only events fire nothing (already covered by diff).

## Manifest
Bumped `0.6.0 → 0.7.0`.

## Test plan
- [x] `pytest tests/` 157/157
- [x] `ruff check .` passes
- [x] `ruff format . --check` passes
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)