### PR TITLE
feat(reauth): re-authentication step in the config flow

### DIFF
--- a/custom_components/hevy/config_flow.py
+++ b/custom_components/hevy/config_flow.py
@@ -2,12 +2,15 @@
 
 from __future__ import annotations
 
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import voluptuous as vol
 from homeassistant import config_entries
 from homeassistant.helpers import selector
 from homeassistant.helpers.aiohttp_client import async_create_clientsession
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
 
 from .api import (
     HevyApiClient,
@@ -87,6 +90,57 @@ class HevyFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                 },
             ),
             errors=_errors,
+        )
+
+    async def async_step_reauth(
+        self,
+        entry_data: Mapping[str, Any],  # noqa: ARG002
+    ) -> config_entries.ConfigFlowResult:
+        """Handle a reauth triggered by ConfigEntryAuthFailed in the coordinator."""
+        return await self.async_step_reauth_confirm()
+
+    async def async_step_reauth_confirm(
+        self,
+        user_input: dict | None = None,
+    ) -> config_entries.ConfigFlowResult:
+        """Prompt the user for a fresh API key and update the existing entry."""
+        errors: dict[str, str] = {}
+        if user_input is not None:
+            try:
+                await self._test_credentials(api_key=user_input[CONF_API_KEY])
+            except HevyApiClientAuthenticationError as exception:
+                LOGGER.warning(exception)
+                errors["base"] = "auth"
+            except HevyApiClientCommunicationError as exception:
+                LOGGER.error(exception)
+                errors["base"] = "connection"
+            except HevyApiClientError as exception:
+                LOGGER.exception(exception)
+                errors["base"] = "unknown"
+            else:
+                entry = self.hass.config_entries.async_get_entry(
+                    self.context["entry_id"]
+                )
+                self.hass.config_entries.async_update_entry(
+                    entry,
+                    data={**entry.data, CONF_API_KEY: user_input[CONF_API_KEY]},
+                    unique_id=user_input[CONF_API_KEY],
+                )
+                await self.hass.config_entries.async_reload(entry.entry_id)
+                return self.async_abort(reason="reauth_successful")
+
+        return self.async_show_form(
+            step_id="reauth_confirm",
+            data_schema=vol.Schema(
+                {
+                    vol.Required(CONF_API_KEY): selector.TextSelector(
+                        selector.TextSelectorConfig(
+                            type=selector.TextSelectorType.PASSWORD,
+                        ),
+                    ),
+                }
+            ),
+            errors=errors,
         )
 
     async def _test_credentials(self, api_key: str) -> None:

--- a/custom_components/hevy/manifest.json
+++ b/custom_components/hevy/manifest.json
@@ -8,5 +8,5 @@
   "documentation": "https://github.com/hudsonbrendon/HA-hevy",
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/hudsonbrendon/HA-hevy/issues",
-  "version": "0.7.0"
+  "version": "0.7.1"
 }

--- a/custom_components/hevy/translations/en.json
+++ b/custom_components/hevy/translations/en.json
@@ -9,7 +9,7 @@
                 }
             },
             "reauth_confirm": {
-                "description": "Your Hevy API key is no longer valid. Generate a new one at https://hevy.com/settings?developer and paste it below.",
+                "description": "Your Hevy API key is no longer valid. Generate a new one in the Hevy web app under Account Settings → Developer, then paste it below.",
                 "data": {
                     "api_key": "API Key"
                 }

--- a/custom_components/hevy/translations/en.json
+++ b/custom_components/hevy/translations/en.json
@@ -7,6 +7,12 @@
                     "api_key": "API Key",
                     "name": "Name"
                 }
+            },
+            "reauth_confirm": {
+                "description": "Your Hevy API key is no longer valid. Generate a new one at https://hevy.com/settings?developer and paste it below.",
+                "data": {
+                    "api_key": "API Key"
+                }
             }
         },
         "error": {
@@ -15,7 +21,8 @@
             "unknown": "An unknown error occurred."
         },
         "abort": {
-            "already_configured": "This API key is already configured."
+            "already_configured": "This API key is already configured.",
+            "reauth_successful": "Re-authentication was successful."
         }
     },
     "options": {

--- a/custom_components/hevy/translations/pt-BR.json
+++ b/custom_components/hevy/translations/pt-BR.json
@@ -9,7 +9,7 @@
                 }
             },
             "reauth_confirm": {
-                "description": "Sua chave de API do Hevy não é mais válida. Gere uma nova em https://hevy.com/settings?developer e cole abaixo.",
+                "description": "Sua chave de API do Hevy não é mais válida. Gere uma nova no app web do Hevy em Configurações da Conta → Desenvolvedor e cole abaixo.",
                 "data": {
                     "api_key": "Chave API"
                 }

--- a/custom_components/hevy/translations/pt-BR.json
+++ b/custom_components/hevy/translations/pt-BR.json
@@ -7,6 +7,12 @@
                     "api_key": "Chave API",
                     "name": "Nome"
                 }
+            },
+            "reauth_confirm": {
+                "description": "Sua chave de API do Hevy não é mais válida. Gere uma nova em https://hevy.com/settings?developer e cole abaixo.",
+                "data": {
+                    "api_key": "Chave API"
+                }
             }
         },
         "error": {
@@ -15,7 +21,8 @@
             "unknown": "Ocorreu um erro desconhecido."
         },
         "abort": {
-            "already_configured": "Esta chave de API já está configurada."
+            "already_configured": "Esta chave de API já está configurada.",
+            "reauth_successful": "Reautenticação concluída com sucesso."
         }
     },
     "options": {

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -125,6 +125,56 @@ class _StubCalendarEntity:
     pass
 
 
+class _StubConfigFlow:
+    """Minimal stand-in for config_entries.ConfigFlow."""
+
+    hass: Any = None
+    context: dict[str, Any]
+    VERSION: int = 1
+
+    def __init_subclass__(cls, **kwargs: Any) -> None:
+        # ConfigFlow uses `class HevyFlowHandler(ConfigFlow, domain="hevy"):`
+        # — accept and discard subclass kwargs in the stub.
+        super().__init_subclass__()
+
+    async def async_set_unique_id(self, unique_id: str) -> None:
+        self._unique_id = unique_id
+
+    def _abort_if_unique_id_configured(self) -> None:
+        pass
+
+    def async_show_form(self, **kwargs: Any) -> dict[str, Any]:
+        return {"type": "form", **kwargs}
+
+    def async_create_entry(self, **kwargs: Any) -> dict[str, Any]:
+        return {"type": "create_entry", **kwargs}
+
+    def async_abort(self, *, reason: str) -> dict[str, Any]:
+        return {"type": "abort", "reason": reason}
+
+
+class _StubOptionsFlow:
+    """Minimal stand-in for config_entries.OptionsFlow."""
+
+    def async_show_form(self, **kwargs: Any) -> dict[str, Any]:
+        return {"type": "form", **kwargs}
+
+    def async_create_entry(self, **kwargs: Any) -> dict[str, Any]:
+        return {"type": "create_entry", **kwargs}
+
+
+class _StubTextSelectorType:
+    TEXT = "text"
+    PASSWORD = "password"  # noqa: S105 (stub mirroring HA enum)
+
+
+def _passthrough_selector(*args: Any, **kwargs: Any) -> Any:
+    """Return a placeholder mirroring the args/kwargs for assertions."""
+    if args:
+        return args[0]
+    return kwargs
+
+
 @dataclass
 class _StubCalendarEvent:
     start: Any
@@ -212,7 +262,28 @@ def _install_ha_stubs() -> None:
         date=_parse_date,
     )
     _mod("homeassistant.core", HomeAssistant=object)
-    _mod("homeassistant.config_entries", ConfigEntry=object)
+    _mod(
+        "homeassistant.config_entries",
+        ConfigEntry=object,
+        ConfigFlow=_StubConfigFlow,
+        OptionsFlow=_StubOptionsFlow,
+        ConfigFlowResult=dict,
+    )
+    _mod(
+        "homeassistant",
+        config_entries=sys.modules["homeassistant.config_entries"],
+    )
+    _mod(
+        "homeassistant.helpers.selector",
+        TextSelector=_passthrough_selector,
+        TextSelectorConfig=_passthrough_selector,
+        TextSelectorType=_StubTextSelectorType,
+    )
+    _mod(
+        "homeassistant.helpers.aiohttp_client",
+        async_get_clientsession=lambda _hass: None,
+        async_create_clientsession=lambda _hass: None,
+    )
     _mod(
         "homeassistant.const",
         Platform=types.SimpleNamespace(
@@ -223,10 +294,6 @@ def _install_ha_stubs() -> None:
         PERCENTAGE="%",
         UnitOfMass=_StubUnitOfMass,
         UnitOfTime=_StubUnitOfTime,
-    )
-    _mod(
-        "homeassistant.helpers.aiohttp_client",
-        async_get_clientsession=lambda _hass: None,
     )
     _mod("homeassistant.loader", async_get_integration=lambda *a, **k: None)
     _pkg("homeassistant.components")
@@ -287,6 +354,7 @@ def _register_hevy_package() -> None:
         "calendar",
         "diagnostics",
         "services",
+        "config_flow",
     ):
         spec = importlib.util.spec_from_file_location(
             f"custom_components.hevy.{submodule}",

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -1,0 +1,86 @@
+"""Tests for HevyFlowHandler — user setup + reauth."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from custom_components.hevy.api import (
+    HevyApiClientAuthenticationError,
+    HevyApiClientCommunicationError,
+)
+from custom_components.hevy.config_flow import HevyFlowHandler
+from custom_components.hevy.const import CONF_API_KEY, CONF_NAME
+
+
+def _make_handler(
+    *,
+    entry_id: str = "entry-abc",
+    test_credentials_side_effect: Any = None,
+) -> HevyFlowHandler:
+    handler = HevyFlowHandler()
+    handler.hass = MagicMock()
+    handler.hass.config_entries.async_get_entry = MagicMock(
+        return_value=SimpleNamespace(
+            entry_id=entry_id, data={CONF_API_KEY: "old-key", CONF_NAME: "Hudson"}
+        )
+    )
+    handler.hass.config_entries.async_update_entry = MagicMock()
+    handler.hass.config_entries.async_reload = AsyncMock()
+    handler.context = {"entry_id": entry_id}
+    handler._test_credentials = AsyncMock(side_effect=test_credentials_side_effect)
+    return handler
+
+
+@pytest.mark.asyncio
+class TestReauthConfirm:
+    async def test_initial_call_shows_form(self) -> None:
+        handler = _make_handler()
+        result = await handler.async_step_reauth_confirm()
+        assert result["type"] == "form"
+        assert result["step_id"] == "reauth_confirm"
+        assert result["errors"] == {}
+
+    async def test_auth_error_keeps_form_with_error(self) -> None:
+        handler = _make_handler(
+            test_credentials_side_effect=HevyApiClientAuthenticationError("bad")
+        )
+        result = await handler.async_step_reauth_confirm(
+            user_input={CONF_API_KEY: "still-bad"}
+        )
+        assert result["type"] == "form"
+        assert result["errors"] == {"base": "auth"}
+
+    async def test_connection_error_shown(self) -> None:
+        handler = _make_handler(
+            test_credentials_side_effect=HevyApiClientCommunicationError("network")
+        )
+        result = await handler.async_step_reauth_confirm(
+            user_input={CONF_API_KEY: "key"}
+        )
+        assert result["errors"] == {"base": "connection"}
+
+    async def test_success_updates_entry_and_reloads(self) -> None:
+        handler = _make_handler(entry_id="entry-abc")
+        result = await handler.async_step_reauth_confirm(
+            user_input={CONF_API_KEY: "new-key"}
+        )
+
+        handler.hass.config_entries.async_update_entry.assert_called_once()
+        update_kwargs = handler.hass.config_entries.async_update_entry.call_args.kwargs
+        assert update_kwargs["data"][CONF_API_KEY] == "new-key"
+        assert update_kwargs["data"][CONF_NAME] == "Hudson"
+        assert update_kwargs["unique_id"] == "new-key"
+
+        handler.hass.config_entries.async_reload.assert_awaited_once_with("entry-abc")
+        assert result == {"type": "abort", "reason": "reauth_successful"}
+
+    async def test_step_reauth_routes_to_confirm(self) -> None:
+        handler = _make_handler()
+        result = await handler.async_step_reauth({"api_key": "old-key"})
+        # First call goes straight to confirm (which shows form when no input).
+        assert result["type"] == "form"
+        assert result["step_id"] == "reauth_confirm"


### PR DESCRIPTION
## What
Adds `async_step_reauth` + `async_step_reauth_confirm` to the config flow so a stale or rotated API key can be replaced without deleting the integration and re-adding every entity from scratch.

## Flow
1. Coordinator raises `ConfigEntryAuthFailed` on 401/403 (already implemented).
2. HA surfaces a "reauthentication needed" notification.
3. User clicks it → form asks for a new API key.
4. New key validated via `_test_credentials`. On success: entry data + `unique_id` updated, entry reloaded, success message shown. On failure: inline error, form re-shown.

## Translations
en + pt-BR strings for `reauth_confirm` description and `reauth_successful` abort reason. Description includes a direct link to `https://hevy.com/settings?developer`.

## Tests
5 new (**162 total passing**): initial form display, auth/connection error rendering, success path (update_entry + reload + abort), `async_step_reauth → reauth_confirm` routing.

## Manifest
Patched `0.7.0 → 0.7.1`.

## Test plan
- [x] `pytest tests/` 162/162
- [x] `ruff check .` passes
- [x] `ruff format . --check` passes
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added dedicated reauthentication flow, enabling users to update their API credentials seamlessly without full reconfiguration

* **Chores**
  * Version bumped to 0.7.1
  * Expanded user interface translations for English and Portuguese (Brazil) with additional reauthentication messaging

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hudsonbrendon/HA-hevy/pull/84?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->