### PR TITLE
feat(services): hevy.create_workout

### DIFF
--- a/custom_components/hevy/api.py
+++ b/custom_components/hevy/api.py
@@ -117,6 +117,14 @@ class HevyApiClient:
             data=body,
         )
 
+    async def async_create_workout(self, body: dict[str, Any]) -> dict[str, Any]:
+        """POST a new workout."""
+        return await self._api_wrapper(
+            method="post",
+            url=f"{BASE_URL}/workouts",
+            data=body,
+        )
+
     async def async_update_body_measurement(
         self, date: str, body: dict[str, Any]
     ) -> dict[str, Any]:

--- a/custom_components/hevy/manifest.json
+++ b/custom_components/hevy/manifest.json
@@ -8,5 +8,5 @@
   "documentation": "https://github.com/hudsonbrendon/HA-hevy",
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/hudsonbrendon/HA-hevy/issues",
-  "version": "0.7.1"
+  "version": "0.8.0"
 }

--- a/custom_components/hevy/services.py
+++ b/custom_components/hevy/services.py
@@ -17,6 +17,7 @@ if TYPE_CHECKING:
 
 SERVICE_LOG_BODY_MEASUREMENT = "log_body_measurement"
 SERVICE_REFRESH = "refresh"
+SERVICE_CREATE_WORKOUT = "create_workout"
 
 ATTR_ENTRY_ID = "entry_id"
 ATTR_DATE = "date"
@@ -56,6 +57,66 @@ LOG_BODY_MEASUREMENT_SCHEMA = vol.Schema(
 )
 
 REFRESH_SCHEMA = vol.Schema({vol.Optional(ATTR_ENTRY_ID): cv.string})
+
+
+def _coerce_iso_datetime(value: Any) -> str:
+    """Accept a datetime, date, or ISO 8601 string and return an ISO string."""
+    if isinstance(value, datetime):
+        return value.isoformat()
+    if isinstance(value, date):
+        return datetime.combine(value, datetime.min.time(), tzinfo=UTC).isoformat()
+    if isinstance(value, str):
+        # Round-trip to validate format (fromisoformat handles trailing Z).
+        try:
+            return datetime.fromisoformat(value).isoformat()
+        except ValueError as err:
+            msg = f"Invalid ISO 8601 timestamp: {value!r}"
+            raise vol.Invalid(msg) from err
+    msg = f"Expected datetime, date, or ISO string; got {type(value).__name__}"
+    raise vol.Invalid(msg)
+
+
+ATTR_TITLE = "title"
+ATTR_DESCRIPTION = "description"
+ATTR_START_TIME = "start_time"
+ATTR_END_TIME = "end_time"
+ATTR_IS_PRIVATE = "is_private"
+ATTR_EXERCISES = "exercises"
+
+_SET_TYPES = ("warmup", "normal", "failure", "dropset")
+
+_SET_SCHEMA = vol.Schema(
+    {
+        vol.Optional("type", default="normal"): vol.In(_SET_TYPES),
+        vol.Optional("weight_kg"): vol.Coerce(float),
+        vol.Optional("reps"): vol.Coerce(int),
+        vol.Optional("distance_meters"): vol.Coerce(int),
+        vol.Optional("duration_seconds"): vol.Coerce(int),
+        vol.Optional("custom_metric"): vol.Coerce(float),
+        vol.Optional("rpe"): vol.Coerce(float),
+    }
+)
+
+_EXERCISE_SCHEMA = vol.Schema(
+    {
+        vol.Required("exercise_template_id"): cv.string,
+        vol.Optional("notes"): cv.string,
+        vol.Optional("superset_id"): vol.Coerce(int),
+        vol.Required("sets"): [_SET_SCHEMA],
+    }
+)
+
+CREATE_WORKOUT_SCHEMA = vol.Schema(
+    {
+        vol.Optional(ATTR_ENTRY_ID): cv.string,
+        vol.Required(ATTR_TITLE): cv.string,
+        vol.Optional(ATTR_DESCRIPTION): cv.string,
+        vol.Required(ATTR_START_TIME): _coerce_iso_datetime,
+        vol.Required(ATTR_END_TIME): _coerce_iso_datetime,
+        vol.Optional(ATTR_IS_PRIVATE, default=False): cv.boolean,
+        vol.Required(ATTR_EXERCISES): vol.All([_EXERCISE_SCHEMA], vol.Length(min=1)),
+    }
+)
 
 
 def _resolve_entry(hass: HomeAssistant, entry_id: str | None) -> Any:
@@ -125,6 +186,31 @@ async def _handle_refresh(hass: HomeAssistant, call: ServiceCall) -> None:
     await entry.runtime_data.coordinator.async_request_refresh()
 
 
+def _build_create_workout_body(call_data: dict[str, Any]) -> dict[str, Any]:
+    """Translate service-call data into the POST /v1/workouts request body."""
+    workout: dict[str, Any] = {
+        "title": call_data[ATTR_TITLE],
+        "start_time": call_data[ATTR_START_TIME],
+        "end_time": call_data[ATTR_END_TIME],
+        "is_private": call_data.get(ATTR_IS_PRIVATE, False),
+        "exercises": call_data[ATTR_EXERCISES],
+    }
+    if call_data.get(ATTR_DESCRIPTION):
+        workout["description"] = call_data[ATTR_DESCRIPTION]
+    return {"workout": workout}
+
+
+async def _handle_create_workout(hass: HomeAssistant, call: ServiceCall) -> None:
+    entry = _resolve_entry(hass, call.data.get(ATTR_ENTRY_ID))
+    body = _build_create_workout_body(call.data)
+    try:
+        await entry.runtime_data.client.async_create_workout(body)
+    except HevyApiClientError as err:
+        msg = f"Failed to create workout: {err}"
+        raise HomeAssistantError(msg) from err
+    await entry.runtime_data.coordinator.async_request_refresh()
+
+
 def async_register_services(hass: HomeAssistant) -> None:
     """Register integration-level services if not already registered."""
     if hass.services.has_service(DOMAIN, SERVICE_LOG_BODY_MEASUREMENT):
@@ -135,6 +221,9 @@ def async_register_services(hass: HomeAssistant) -> None:
 
     async def refresh(call: ServiceCall) -> None:
         await _handle_refresh(hass, call)
+
+    async def create_workout(call: ServiceCall) -> None:
+        await _handle_create_workout(hass, call)
 
     hass.services.async_register(
         DOMAIN,
@@ -148,6 +237,12 @@ def async_register_services(hass: HomeAssistant) -> None:
         refresh,
         schema=REFRESH_SCHEMA,
     )
+    hass.services.async_register(
+        DOMAIN,
+        SERVICE_CREATE_WORKOUT,
+        create_workout,
+        schema=CREATE_WORKOUT_SCHEMA,
+    )
 
 
 def async_unregister_services(hass: HomeAssistant) -> None:
@@ -156,3 +251,4 @@ def async_unregister_services(hass: HomeAssistant) -> None:
         return
     hass.services.async_remove(DOMAIN, SERVICE_LOG_BODY_MEASUREMENT)
     hass.services.async_remove(DOMAIN, SERVICE_REFRESH)
+    hass.services.async_remove(DOMAIN, SERVICE_CREATE_WORKOUT)

--- a/custom_components/hevy/services.yaml
+++ b/custom_components/hevy/services.yaml
@@ -61,3 +61,65 @@ refresh:
       example: "abc123def456"
       selector:
         text:
+
+create_workout:
+  name: Create workout
+  description: >
+    POST a completed workout to Hevy. Useful for scripted/automated logging
+    (e.g. tracking treadmill sessions or warmups recorded by another
+    integration). Refreshes the coordinator on success.
+  fields:
+    entry_id:
+      name: Config entry
+      description: ID of the Hevy integration to target (omit if only one is configured).
+      required: false
+      example: "abc123def456"
+      selector:
+        text:
+    title:
+      name: Title
+      required: true
+      example: "Morning Cardio"
+      selector:
+        text:
+    description:
+      name: Description
+      required: false
+      example: "30 min steady state on the treadmill"
+      selector:
+        text:
+          multiline: true
+    start_time:
+      name: Start time (ISO 8601)
+      required: true
+      example: "2026-05-17T07:30:00Z"
+      selector:
+        datetime:
+    end_time:
+      name: End time (ISO 8601)
+      required: true
+      example: "2026-05-17T08:00:00Z"
+      selector:
+        datetime:
+    is_private:
+      name: Private
+      description: Hide the workout from your public Hevy profile.
+      required: false
+      default: false
+      selector:
+        boolean:
+    exercises:
+      name: Exercises
+      description: >
+        List of exercise objects. Each must have exercise_template_id and a
+        sets list. Each set may include type, weight_kg, reps,
+        distance_meters, duration_seconds, custom_metric and rpe.
+      required: true
+      example: |
+        - exercise_template_id: "D04AC939"
+          sets:
+            - type: normal
+              weight_kg: 100
+              reps: 8
+      selector:
+        object:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -260,6 +260,7 @@ def _install_ha_stubs() -> None:
         "homeassistant.helpers.config_validation",
         string=str,
         date=_parse_date,
+        boolean=bool,
     )
     _mod("homeassistant.core", HomeAssistant=object)
     _mod(

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -16,10 +16,19 @@ from custom_components.hevy.api import (
 )
 from custom_components.hevy.services import (
     ATTR_DATE,
+    ATTR_DESCRIPTION,
+    ATTR_END_TIME,
     ATTR_ENTRY_ID,
+    ATTR_EXERCISES,
     ATTR_FAT_PERCENT,
+    ATTR_IS_PRIVATE,
+    ATTR_START_TIME,
+    ATTR_TITLE,
     ATTR_WEIGHT_KG,
+    _build_create_workout_body,
     _build_measurement_payload,
+    _coerce_iso_datetime,
+    _handle_create_workout,
     _handle_log_body_measurement,
     _handle_refresh,
     _resolve_entry,
@@ -38,6 +47,7 @@ def _make_entry(entry_id: str = "abc") -> Any:
     client = MagicMock()
     client.async_create_body_measurement = AsyncMock()
     client.async_update_body_measurement = AsyncMock()
+    client.async_create_workout = AsyncMock()
     coordinator = MagicMock()
     coordinator.async_request_refresh = AsyncMock()
     entry.runtime_data = SimpleNamespace(client=client, coordinator=coordinator)
@@ -190,3 +200,117 @@ class TestRefresh:
         hass = _make_hass([entry])
         await _handle_refresh(hass, SimpleNamespace(data={}))
         entry.runtime_data.coordinator.async_request_refresh.assert_awaited_once()
+
+
+class TestCoerceIsoDatetime:
+    def test_datetime_passthrough(self) -> None:
+        dt = datetime(2026, 5, 17, 9, 0, tzinfo=UTC)
+        assert _coerce_iso_datetime(dt) == dt.isoformat()
+
+    def test_date_to_midnight_utc(self) -> None:
+        result = _coerce_iso_datetime(date(2026, 5, 17))
+        assert result.startswith("2026-05-17T00:00:00")
+
+    def test_iso_string_normalized(self) -> None:
+        assert _coerce_iso_datetime("2026-05-17T09:00:00Z").startswith(
+            "2026-05-17T09:00:00"
+        )
+
+    def test_invalid_string_raises(self) -> None:
+        import voluptuous as vol
+
+        with pytest.raises(vol.Invalid):
+            _coerce_iso_datetime("not-a-date")
+
+    def test_invalid_type_raises(self) -> None:
+        import voluptuous as vol
+
+        with pytest.raises(vol.Invalid):
+            _coerce_iso_datetime(42)
+
+
+class TestBuildCreateWorkoutBody:
+    def test_minimal_workout(self) -> None:
+        body = _build_create_workout_body(
+            {
+                ATTR_TITLE: "Test",
+                ATTR_START_TIME: "2026-05-17T09:00:00+00:00",
+                ATTR_END_TIME: "2026-05-17T10:00:00+00:00",
+                ATTR_EXERCISES: [
+                    {"exercise_template_id": "T1", "sets": [{"reps": 10}]}
+                ],
+            }
+        )
+        assert body["workout"]["title"] == "Test"
+        assert body["workout"]["is_private"] is False
+        assert "description" not in body["workout"]
+        assert body["workout"]["exercises"][0]["exercise_template_id"] == "T1"
+
+    def test_with_description_and_private(self) -> None:
+        body = _build_create_workout_body(
+            {
+                ATTR_TITLE: "Test",
+                ATTR_DESCRIPTION: "Notes",
+                ATTR_START_TIME: "x",
+                ATTR_END_TIME: "y",
+                ATTR_IS_PRIVATE: True,
+                ATTR_EXERCISES: [],
+            }
+        )
+        assert body["workout"]["description"] == "Notes"
+        assert body["workout"]["is_private"] is True
+
+    def test_empty_description_omitted(self) -> None:
+        body = _build_create_workout_body(
+            {
+                ATTR_TITLE: "Test",
+                ATTR_DESCRIPTION: "",
+                ATTR_START_TIME: "x",
+                ATTR_END_TIME: "y",
+                ATTR_EXERCISES: [],
+            }
+        )
+        assert "description" not in body["workout"]
+
+
+@pytest.mark.asyncio
+class TestCreateWorkoutHandler:
+    async def test_happy_path_posts_and_refreshes(self) -> None:
+        entry = _make_entry()
+        hass = _make_hass([entry])
+        call = SimpleNamespace(
+            data={
+                ATTR_TITLE: "Test",
+                ATTR_START_TIME: "2026-05-17T09:00:00+00:00",
+                ATTR_END_TIME: "2026-05-17T10:00:00+00:00",
+                ATTR_EXERCISES: [
+                    {"exercise_template_id": "T1", "sets": [{"reps": 10}]}
+                ],
+            }
+        )
+
+        await _handle_create_workout(hass, call)
+
+        entry.runtime_data.client.async_create_workout.assert_awaited_once()
+        body = entry.runtime_data.client.async_create_workout.await_args.args[0]
+        assert body["workout"]["title"] == "Test"
+        entry.runtime_data.coordinator.async_request_refresh.assert_awaited_once()
+
+    async def test_api_error_wraps_as_homeassistant_error(self) -> None:
+        from custom_components.hevy.api import HevyApiClientError
+
+        entry = _make_entry()
+        entry.runtime_data.client.async_create_workout.side_effect = HevyApiClientError(
+            "server boom"
+        )
+        hass = _make_hass([entry])
+        call = SimpleNamespace(
+            data={
+                ATTR_TITLE: "Test",
+                ATTR_START_TIME: "x",
+                ATTR_END_TIME: "y",
+                ATTR_EXERCISES: [],
+            }
+        )
+        with pytest.raises(HomeAssistantError):
+            await _handle_create_workout(hass, call)


### PR DESCRIPTION
Closes #73.

## What
POSTs a completed workout to Hevy. Useful for scripted/automated logging — e.g. record a treadmill session from another HA integration, or batch-import past sessions.

```yaml
service: hevy.create_workout
data:
  title: "Morning Cardio"
  start_time: "2026-05-17T07:30:00+00:00"
  end_time: "2026-05-17T08:00:00+00:00"
  description: "30 min steady state"
  exercises:
    - exercise_template_id: "D04AC939"
      sets:
        - type: normal
          duration_seconds: 1800
          custom_metric: 3500   # e.g. steps on the stair machine
```

## Schema (voluptuous-validated)
- `entry_id` (optional, multi-instance support)
- `title` (required)
- `description` (optional)
- `start_time` / `end_time` (required) — accepts ISO 8601 string, `datetime`, or `date`
- `is_private` (optional, default false)
- `exercises` (required, ≥1):
  - `exercise_template_id` (required)
  - `notes` / `superset_id` (optional)
  - `sets` (required, list):
    - `type` (default `normal`; enum `warmup`/`normal`/`failure`/`dropset`)
    - `weight_kg`, `reps`, `distance_meters`, `duration_seconds`, `custom_metric`, `rpe` — all optional, coerced

## API
- `async_create_workout(body)` → POST `/v1/workouts`

## Helper
- `_coerce_iso_datetime` accepts a datetime / date / ISO 8601 string and raises `vol.Invalid` otherwise. Lets users pass HA `datetime:` selector output straight through.

## Tests
10 new (**172 total passing**):
- `_coerce_iso_datetime` happy paths + invalid string + invalid type.
- `_build_create_workout_body`: minimal, with description, empty-description omitted.
- `_handle_create_workout`: happy path POST + coordinator refresh; API error wrapped as `HomeAssistantError`.

## Manifest
Bumped `0.7.1 → 0.8.0`.

## Test plan
- [x] `pytest tests/` 172/172
- [x] `ruff check .` passes
- [x] `ruff format . --check` passes
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)